### PR TITLE
外部キー制約の解除

### DIFF
--- a/db/migrate/20231212073237_remove_foreign_key_constraint_from_feeling_type_mappings.rb
+++ b/db/migrate/20231212073237_remove_foreign_key_constraint_from_feeling_type_mappings.rb
@@ -1,0 +1,7 @@
+class RemoveForeignKeyConstraintFromFeelingTypeMappings < ActiveRecord::Migration[7.1]
+  def change
+    # FeelingTypeMappings テーブルから外部キー制約を削除
+    remove_foreign_key :feeling_type_mappings, :feelings, column: :feeling_id
+    remove_foreign_key :feeling_type_mappings, :google_places_api_types, column: :google_places_api_type_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_06_070025) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_12_073237) do
   create_table "feeling_type_mappings", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "feeling_id", null: false
     t.bigint "google_places_api_type_id", null: false
@@ -33,6 +33,4 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_06_070025) do
     t.datetime "updated_at", null: false
   end
 
-  add_foreign_key "feeling_type_mappings", "feelings"
-  add_foreign_key "feeling_type_mappings", "google_places_api_types"
 end


### PR DESCRIPTION
## 概要

デプロイエラーの解消のため、PlanetScaleの仕様に併せてFeelingTypeMappingsテーブルから外部キー制約を解除した。

close #37  

## やったこと

- 外部キー制約解除のためのマイグレーションファイル作成
- rails db:migrate
- schemaファイル確認

## やらないこと

無し

## できるようになること（ユーザ目線）

無し

## できなくなること（ユーザ目線）

無し

## 動作確認

db/schema.rbで外部キー制約が外れていることを確認

## 確認方法
(省略)

## 影響範囲
(省略)

## チェックリスト
(省略)

## コメント, その他
#### 解除の理由
- PlanetScaleが外部キー制約を公式的にサポートしてないため、`feeling_type_mappings`テーブルに外部キー制約がついた今の状態ではデプロイに失敗してしまう。
- 現状作成している3つのテーブル(`feelings`, `google_places_api_types`, `feeling_type_mappings`)は、固定のレコードを保有するものであり、頻繁なレコードの作成や削除は想定されていない。外部キー制約をつけておくメリットを享受しづらいと考えられるため、このテーブル群の関係に関しては外部キー制約を外して進める。
- 今後作成するテーブルにおいて外部キー制約が必要になった場合には同じデプロイエラーが発生しうるので、外部キー制約を用いない実装方法を検討するのか、外部キー制約がサポートされているベータ版PlanetScaleでの機能を導入するのか、考えて進める。