### PR TITLE
外部キー制約を有効化する記述の削除 (hotfix → main)

### DIFF
--- a/db/migrate/20231206070025_create_feeling_type_mappings.rb
+++ b/db/migrate/20231206070025_create_feeling_type_mappings.rb
@@ -1,8 +1,8 @@
 class CreateFeelingTypeMappings < ActiveRecord::Migration[7.1]
   def change
     create_table :feeling_type_mappings do |t|
-      t.references :feeling, null: false, foreign_key: true
-      t.references :google_places_api_type, null: false, foreign_key: true
+      t.references :feeling, null: false
+      t.references :google_places_api_type, null: false
 
       t.timestamps
     end

--- a/db/migrate/20231212073237_remove_foreign_key_constraint_from_feeling_type_mappings.rb
+++ b/db/migrate/20231212073237_remove_foreign_key_constraint_from_feeling_type_mappings.rb
@@ -1,7 +1,0 @@
-class RemoveForeignKeyConstraintFromFeelingTypeMappings < ActiveRecord::Migration[7.1]
-  def change
-    # FeelingTypeMappings テーブルから外部キー制約を削除
-    remove_foreign_key :feeling_type_mappings, :feelings, column: :feeling_id
-    remove_foreign_key :feeling_type_mappings, :google_places_api_types, column: :google_places_api_type_id
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_12_073237) do
+ActiveRecord::Schema[7.1].define(version: 2023_12_06_070025) do
   create_table "feeling_type_mappings", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.bigint "feeling_id", null: false
     t.bigint "google_places_api_type_id", null: false


### PR DESCRIPTION
## 概要
Issue: #40 

外部キー制約が貼られていた中間テーブルである`Feeling_type_mappings`を作成するマイグレーションファイルから、外部キー制約を有効化する`foreign_key: true`の記述を削除した。

## やったこと

- Feeling_type_mappingsテーブルを作成するマイグレーションファイルまでrollbackし、foreign_key: trueを削除する
- 改めてrails db:migrate実行

## やらないこと

無し

## できるようになること（ユーザ目線）

無し

## できなくなること（ユーザ目線）

無し

## 動作確認

- 編集後のマイグレーションファイルに、`foreign_key: true`がないことを確認
- db/schema.rbに外部キー制約に関する記述がないことを確認

## 確認方法

(省略)

## 影響範囲

(省略)

## チェックリスト

(省略)

## コメント, その他
#### 修正の理由
- #37 において、一度有効化してしまった外部キー制約を後から解除するためのマイグレーションファイルを作成して実行したが、デプロイ時には依然と同じく「外部キー制約はサポートしていない」というエラーが発生した。
- 調査＆GPTとの確認の結果、後から解除して無効化しているか否かはあまり重要ではなく、そもそも最初に`foreign_key: true`で外部キー制約を有効化してしまっているところが根本原因かと思われる。ビルド時にその部分が読み込まれた時点でエラーが発生しているため、その後のマイグレーションファイルで無効化していても恐らく意味はない。
- 従い、`Feeling_type_mappings`テーブルを作成するマイグレーションファイルでの`foreign_key: true`という記述自体を削除する必要があると考えられる。当該マイグレーションファイルまでrollbackしてから該当の記述を削除し、再度マイグレーションを実行した上でデプロイできるか改めて確認する
