### PR TITLE
ユーザーが現在地取得の許可をしてから選択フォーム画面に遷移するよう修正 (mainブランチへマージ)

### DIFF
--- a/app/views/searches/index.html.erb
+++ b/app/views/searches/index.html.erb
@@ -7,11 +7,13 @@
 
 <script>
   const locationButton = document.getElementById('search-location')
-  locationButton.addEventListener('click', () => {
+  locationButton.addEventListener('click', (event) => {
+    event.preventDefault(); // デフォルトでの画面遷移をキャンセル
     if (navigator.geolocation) {
       navigator.geolocation.getCurrentPosition((position) => {
         sessionStorage.setItem('latitude', position.coords.latitude);
         sessionStorage.setItem('longitude', position.coords.longitude);
+        window.location.href = <%= new_search_path %>; // 現在地情報の取得後に画面遷移する
       }, showError);
     } else {
       // ここは、とりあえずは画面上にアラート的な感じでメッセージが表示されればOKとする。


### PR DESCRIPTION
## 概要
ISSUE: #46 

Geolocation APIでの現在地取得処理が完了してから`searches/new`に画面遷移するように修正

## やったこと

`app/views/searches/index.html.erb`での現在地取得処理において、Geolocation APIでの現在地取得処理が完了してから`searches/new`に画面遷移するように修正
  - `event.preventDefault`を追記して、デフォルトの画面遷移処理を止めてから現在地取得処理を実行し、取得後に`window.location.href = <%= new_search_path %>`で画面遷移するように修正

## やらないこと

なし

## できるようになること（ユーザ目線）

位置情報の取得を許可した上で画面が切り替わり、選択フォームで選択できる

## できなくなること（ユーザ目線）

無し

## 動作確認

- トップページで「行き先を探す」ボタンを押した際に位置情報取得の許可を求めるポップアップが表示される
- 許可した後に`searches/new`に遷移する
- `searches/new`では、取得した緯度と経度が`hidden_field`にセットされている。

## 確認方法

## 影響範囲

## チェックリスト

## コメント, その他
#### 本番環境での挙動確認時に発生した不具合
- 現在地取得の許可をする前に画面遷移してしまい、選択フォーム画面(`searches/new`)に緯度と経度の情報が渡されていない
- (緯度と経度が渡されていないことが関係あるかわからないが)選択フォームの要素が崩れ、表示されてほしい要素が表示されていない

#### 考えられる原因
- トップページで「行き先を探す」というリンクを押した際にGeolocation APIを用いて現在地を取得するJavaScriptコードにおいて、デフォルトの画面遷移処理を止めずに現在地を取得する処理を書いていた。
- そのため、現在地取得に関してユーザーからの許可を取得するポップアップ(恐らくGeocoding APIによる現在地取得処理の一部)が表示される前に、デフォルトの画面遷移処理が走ってしまい、ユーザーから許可を得ない状態で次の画面に遷移していたものと考えられる。
- 結果、ユーザーからの許可がないために現在地の取得が行えないまま画面遷移が実行されてしまったと考えられる。

#### その他
- フォームの要素崩れの原因はハッキリわからないので、一旦現在地情報の取得に関する不具合を修正して様子を見る。
- 現在地取得処理の実行後に画面遷移すると4秒ほどの待機時間が発生してしまうため、ローディング中にアニメーションのようなものを挟むなどユーザー体験を損ねないような工夫を後々考えて実装する必要がある。
  -  この後実装するPlaces APIへのリクエストとタイミングを合わせて現在地情報を取得するという構成も検討する。
     (トップページから選択フォーム画面への遷移時に待機時間があるよりも、選択フォームで条件を選択して検索実行した際に多少待機時間ある方がまだ許容できそう)。この場合でも、いずれにせよローディング中のユーザー体験に関する対応は必要。
