### PR TITLE
デプロイエラー解消

### DIFF
--- a/app/services/search_places_service.rb
+++ b/app/services/search_places_service.rb
@@ -28,8 +28,6 @@ class SearchPlacesService
     JSON.parse(response.body)
   end
 
-  private_class_method :build_field_mask  # クラスメソッドであるbuild_field_maskをプライベート化。privateキーワードはインスタンスのコンテキストに基づいて動作するもので、クラスメソッドには適用されないため左記の記載としている。
-
   def self.build_field_mask
     [
       'places.types', 'places.addressComponents', 'places.location',
@@ -39,4 +37,6 @@ class SearchPlacesService
       'places.primaryType', 'places.restroom'
     ].join(',')
   end
+
+  private_class_method :build_field_mask # クラスメソッドであるbuild_field_maskをプライベート化。privateキーワードはインスタンスのコンテキストに基づいて動作するもので、クラスメソッドには適用されないため左記の記載としている。
 end


### PR DESCRIPTION
## 概要
ISSUE: #57 

デプロイエラー(NameError)の原因を解消

## やったこと

- [x]  `app/services/serch_places_service.rb`の`private_class_method :build_field_mask`を、`build_field_mask`メソッドの定義箇所以降に記述するよう修正
