### PR TITLE
情報ウィンドウ表示機能の実装 

### DIFF
--- a/app/views/searches/result.html.erb
+++ b/app/views/searches/result.html.erb
@@ -52,12 +52,21 @@
       const marker = new google.maps.Marker({
         position: markerPosition,
         map: map,
-        title: place['displayName']['text']
       });
+
+      // 情報ウィンドウに表示する内容を定義する
+      const infowindowContent = `
+        <div class="text-center">
+        <h1 class="font-bold">${place['displayName']['text']}</h1>
+        <div>
+        <p>${place['primaryType']}</p>
+        <a href="${place['websiteUri']}">サイトURL</a>
+        </div>
+        </div>`
 
       // 情報ウィンドウオブジェクトを作成
       const infowindow = new google.maps.InfoWindow({
-        content: 'Information'
+        content: infowindowContent
       })
 
       marker.addListener('click', () => {

--- a/app/views/searches/result.html.erb
+++ b/app/views/searches/result.html.erb
@@ -39,6 +39,8 @@
       center: mapCenter
     });
 
+    let openInfoWindow = null; // 現在開いている情報ウィンドウを変数で管理
+
     // 検索結果として表示する各場所に対して繰り返し処理を定義し、マーカーを作成
     places.forEach(function(place) {
       const markerPosition = {
@@ -52,6 +54,23 @@
         map: map,
         title: place['displayName']['text']
       });
+
+      // 情報ウィンドウオブジェクトを作成
+      const infowindow = new google.maps.InfoWindow({
+        content: 'Information'
+      })
+
+      marker.addListener('click', () => {
+        // 別のマーカーがクリックされた際に、既に開いている情報ウィンドウを閉じる
+        if (openInfoWindow) {
+          openInfoWindow.close();
+        }
+        infowindow.open({
+          anchor: marker,
+          map: map
+        });
+        openInfoWindow = infowindow // 開いた情報ウィンドウを変数に入れて管理
+      })
     });
   }
 </script>


### PR DESCRIPTION
## 概要
ISSUE: #54 

マップ上のマーカークリック時に、その場所の情報を示す情報ウィンドウが表示されるように実装した

close #54 

## やったこと

- [x] `Maps JavaScript API`の情報ウィンドウ表示機能を用いて、各マーカーをクリックした際に表示されるようにする
- [x] 情報ウィンドウは二つ以上同時に表示されないようにする
- [x] 情報ウィンドウの中身を、`Places API`から取得した各場所のデータとする

## やらないこと

- 各場所の名称を示すリスト項目とマップ上のマーカーとの紐付け

## できるようになること（ユーザ目線）

- マップ上のマーカーをクリックすると、その場所の情報を閲覧できる
  (現状では名称と場所のタイプ、WebサイトURLを仮で表示している)

## できなくなること（ユーザ目線）

無し

## 動作確認

- ブラウザでマーカーをクリックして動作確認。
  - マーカーをクリックすると情報ウィンドウが表示されること
  - 複数のマーカーを順にクリックしても、最後にクリックされたマーカーの情報ウィンドウのみ表示されること
  - 情報ウィンドウの中身が、マーカーで示される各場所に応じたデータになっていること
  - WebサイトURLの遷移先も一応確認

## 確認結果
[![Image from Gyazo](https://i.gyazo.com/cd2f43e18a0ca14b24af907164412083.png)](https://gyazo.com/cd2f43e18a0ca14b24af907164412083)

[![Image from Gyazo](https://i.gyazo.com/3f2ff37a2e59383bd89ed184b01b0015.png)](https://gyazo.com/3f2ff37a2e59383bd89ed184b01b0015)


- WebサイトURLの遷移先も問題なし。

## チェックリスト

- [x] Lint のチェックをパスした

