### PR TITLE
Yahoo!カーナビを利用した経路案内機能の実装  (mainブランチへマージ)

### DIFF
--- a/app/views/searches/result.html.erb
+++ b/app/views/searches/result.html.erb
@@ -61,6 +61,7 @@
         <div>
         <p>${place['primaryType']}</p>
         <a href="${place['websiteUri']}">サイトURL</a>
+        <a href="yjcarnavi://navi/select?lat=${place['location']['latitude']}&lon=${place['location']['longitude']}">ここに行く</a>
         </div>
         </div>`
 


### PR DESCRIPTION
## 概要
ISSUE: #61 

- マップ上の各マーカーに、その場所への経路案内をYahoo!カーナビで起動できるURLスキームを追記

## やったこと

- 情報ウィンドウでの表示内容に、Yahoo!カーナビでのナビ起動のためのURLスキームを追記
  - URLスキームには、各場所の緯度と経度を動的に渡している

## できるようになること（ユーザ目線）

- 各マーカーの情報ウィンドウにある「ここに行く」ボタンを押すと、その場所への経路案内をYahoo!カーナビで起動できる

## コメント, その他

- Yahoo!カーナビの起動は、ユーザーの端末にYahoo!カーナビアプリがインストールされていることが前提となるため、追ってその旨の案内を記載する必要がある。
  - ユーザーの端末は、スマホを想定している。PCではYahoo!カーナビアプリをインストールできないため。
