### PR TITLE
フラッシュメッセージのスタイル修正 

### DIFF
--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,6 +1,19 @@
 <% flash.each do |type, message| %>
-  <!-- flash_classメソッドはapp/helpers/flash_helper.rbで定義している -->
-  <div class="<%= flash_class(type) %> w-full p-4 mb-4 rounded">
-    <%= message %>
-  </div>
+  <% case type %>
+  <% when 'success' %>
+    <div class="bg-green-100 text-green-800 w-full p-4 mb-4 rounded">
+      <%= message %>
+    </div>
+  <% when 'danger' %>
+    <div class="bg-red-100 text-red-800 w-full p-4 mb-4 rounded">
+      <%= message %>
+    </div>
+  <% end %>
 <% end %>
+
+<!-- 元々は、アプリ内でtailwindのカスタムスタイルを作成し、fkashのtypeに応じて、ここで動的にスタイルを当てる仕組みにしたかった。 -->
+<!-- しかしカスタムスタイルの読み込みがうまくできなかったので、現状は上記の通り条件分岐して直接スタイル当てている。カスタムスタイルの読み込みなどを調べて、可能であればカスタムスタイルの実装を試みる。 -->
+<!-- 以下は、カスタムスタイル作成時に変更を加えたファイル。それ以降の変更は、現状加えていない。 -->
+<!-- app/helpers/flash_helper.rb -->
+<!-- app/stylesheets/flash_messages.css -->
+<!-- app/assets/stylesheets/application.tailwind.css -->


### PR DESCRIPTION
## 概要
ISSUE: #70 

フラッシュメッセージにtailwindスタイルが当たるようコードを修正

close #70 

## やったこと

- [x] フラッシュにsuccessまたはdangerが設定された場合、その内容に応じて条件分岐して当てるスタイルを分ける処理をapp/views/shared/_flash_message.html.erbに記述

## やらないこと

無し

## 動作確認

- `searches/new`で、全ての項目を漏れなく選択して検索ボタンを押下
- 「成功」というフラッシュメッセージにスタイルが当たっていることを確認
[![Image from Gyazo](https://i.gyazo.com/c21d5ea247e589efe077a9fab6ad967f.png)](https://gyazo.com/c21d5ea247e589efe077a9fab6ad967f)


- `searches/new`で、選択項目に漏れがある状態で検索ボタンを押下
- 「失敗」というフラッシュメッセージにスタイルが当たっていることを確認
[![Image from Gyazo](https://i.gyazo.com/e7068ab97f57d9c6ff30770b6a2008a4.png)](https://gyazo.com/e7068ab97f57d9c6ff30770b6a2008a4)
 

## チェックリスト

- [ ] Lint のチェックをパスした