### PR TITLE
ユーザー登録完了後はログイン状態にする

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -7,6 +7,7 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
+      auto_login(@user)
       redirect_to root_path, flash: { success: "ユーザー登録が完了しました" }
     else
       flash.now[:danger] = "ユーザー登録に失敗しました"


### PR DESCRIPTION
## 概要
ISSUE: #110

 ユーザー登録後に自動でログイン状態となるよう、`Users#create`を修正

close #110 

## やったこと

 ユーザー登録後に自動でログイン状態となるよう、`Users#create`のユーザー登録作成時の処理に`auto_login(@user)`

## やらないこと

なし

## できるようになること（ユーザ目線）

- ユーザー登録後に自動でログイン状態となり、ログインユーザー向けの機能を利用できる

## できなくなること（ユーザ目線）

なし

## 動作確認

- `users#new`に遷移し、フォームに情報を入力してユーザー登録を実行
- 「ユーザー登録が完了しました」というフラッシュメッセージとともにトップページに遷移し、ログイン後のヘッダーが表示されていることを確認
[![Image from Gyazo](https://i.gyazo.com/9a45b540f1e93265ff3c9f3d2c52c646.png)](https://gyazo.com/9a45b540f1e93265ff3c9f3d2c52c646)

## 確認方法

1. `users#new`に遷移し、フォームに情報を入力してユーザー登録を行なってください
2. ユーザー登録が完了しました」というフラッシュメッセージとともにトップページに遷移し、ログイン後のヘッダーが表示されていることを確認してください

## チェックリスト

- [x] Lint のチェックをパスした
