### PR TITLE
プロフィール表示 / 閲覧機能

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,0 +1,3 @@
+class ProfilesController < ApplicationController
+  def show; end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,3 +1,26 @@
 class ProfilesController < ApplicationController
+  before_action :set_user, only: %i[edit update]
+
   def show; end
+
+  def edit; end
+
+  def update
+    if @user.update(user_params)
+      redirect_to profile_path, flash: { success: 'プロフィールを更新しました' }
+    else
+      flash.now[:danger] = 'プロフィールの更新に失敗しました'
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(current_user.id)
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email)
+  end
 end

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,0 +1,22 @@
+<div class="flex justify-center">
+  <div class="w-full max-w-md px-4">
+    <h1 class="text-2xl font-bold text-center mb-4">プロフィール編集</h1>
+    <%= form_with model: @user, url: profile_path, local: true do |f| %>
+      <%= render 'shared/error_messages', object: @user %>
+      <div class="mb-4">
+        <%= f.label :name, class: 'block text-sm font-medium text-gray-700' %>
+        <%= f.text_field :name, class: 'mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm' %>
+      </div>
+      <div class="mb-4">
+        <%= f.label :email, class: 'block text-sm font-medium text-gray-700' %>
+        <%= f.email_field :email, class: 'mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm' %>
+      </div>
+      <div class="mb-6 flex justify-center">
+        <%= f.submit '編集', class: 'w-2/3 text-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500' %>
+      </div>
+    <% end %>
+    <div class='text-center'>
+      <%= link_to '戻る', profile_path, class: 'text-indigo-600 hover:text-indigo-500' %>
+    </div>
+  </div>
+</div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -21,7 +21,7 @@
       </tr>
     </table>
     <div class='text-center mt-4'>
-      <%= link_to '編集', '#', class: 'text-indigo-600 hover:text-indigo-500' %>
+      <%= link_to '編集', edit_profile_path, class: 'text-indigo-600 hover:text-indigo-500' %>
     </div>
   </div>
 </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -1,0 +1,27 @@
+<div class="flex justify-center">
+  <div class="w-full max-w-md px-4">
+    <h1 class="text-2xl font-bold text-center mb-4">プロフィール</h1>
+    
+    <table class="table-auto">
+      <tr>
+        <th scope="row" class="align-top text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+          <p>ユーザー名</p>
+        </th>
+        <td class="px-6 py-3 whitespace-nowrap">
+          <%= current_user.name %>
+        </td>
+      </tr>
+      <tr>
+        <th scope="row" class="align-top text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wider">
+          <p>メールアドレス</p>
+        </th>
+        <td class="px-6 py-3 whitespace-nowrap">
+          <%= current_user.email %>
+        </td>
+      </tr>
+    </table>
+    <div class='text-center mt-4'>
+      <%= link_to '編集', '#', class: 'text-indigo-600 hover:text-indigo-500' %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,7 +3,7 @@
     <%= link_to 'トップページ', root_path, class: 'text-slate-50 font-bold inline-block p-5' %>
     <div>
       <%= link_to 'ブックマーク', '#', class: 'text-slate-50 font-bold inline-block p-5' %>
-      <%= link_to 'プロフィール', '#', class: 'text-slate-50 font-bold inline-block p-5' %>
+      <%= link_to 'プロフィール', profile_path, class: 'text-slate-50 font-bold inline-block p-5' %>
       <%= link_to 'ログアウト', logout_path, class: 'text-slate-50 font-bold inline-block p-5', data: { turbo_method: :delete } %>
     </div>
   </nav>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,10 +1,10 @@
 <header>
   <nav class='flex items-center justify-between bg-cyan-800 h-20'>
-    <%= link_to 'トップページ', root_path, class: 'text-slate-50 font-bold inline-block p-5' %>
-    <div>
-      <%= link_to 'ブックマーク', '#', class: 'text-slate-50 font-bold inline-block p-5' %>
-      <%= link_to 'プロフィール', profile_path, class: 'text-slate-50 font-bold inline-block p-5' %>
-      <%= link_to 'ログアウト', logout_path, class: 'text-slate-50 font-bold inline-block p-5', data: { turbo_method: :delete } %>
+    <%= link_to 'トップページ', root_path, class: 'text-slate-50 font-bold inline-block p-3' %>
+    <div class='flex items-center'>
+      <%= link_to 'ブックマーク', '#', class: 'text-slate-50 font-bold inline-block p-3' %>
+      <%= link_to 'プロフィール', profile_path, class: 'text-slate-50 font-bold inline-block p-3' %>
+      <%= link_to 'ログアウト', logout_path, class: 'text-slate-50 font-bold inline-block p-3', data: { turbo_method: :delete } %>
     </div>
   </nav>
 </header>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -19,7 +19,9 @@
         <%= f.label :password_confirmation, class: 'block text-sm font-medium text-gray-700' %>
         <%= f.password_field :password_confirmation, class: 'mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm' %>
       </div>
-      <%= f.submit '登録', class: 'w-full flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500' %>
+      <div class="mb-6 flex justify-center">
+        <%= f.submit '登録', class: 'w-2/3 text-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500' %>
+      </div>
     <% end %>
     <div class='text-center mt-4'>
       <%= link_to 'ログインページへ', login_path, class: 'text-indigo-600 hover:text-indigo-500' %>

--- a/app/views/usersessions/new.html.erb
+++ b/app/views/usersessions/new.html.erb
@@ -10,7 +10,7 @@
         <%= f.label :password, class: 'block text-sm font-medium text-gray-700' %>
         <%= f.password_field :password, class: 'mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm' %>
       </div>
-      <div class="actions mb-6 flex justify-center">
+      <div class="mb-6 flex justify-center">
         <%= f.submit 'ログイン', class: 'w-2/3 text-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500' %>
       </div>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   get "oauth/callback" => "oauths#callback"
   get "oauth/:provider" => "oauths#oauth", as: :auth_at_provider
 
-  resource :profile, only: %i[show]
+  resource :profile, only: %i[show edit update]
 
   resources :password_resets, only: %i[new create edit update]
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,12 +15,12 @@ Rails.application.routes.draw do
   get 'login', to: 'usersessions#new'
   post 'login', to: 'usersessions#create'
   delete 'logout', to: 'usersessions#destroy'
-
-  resources :password_resets, only: %i[new create edit update]
-
   post "oauth/callback" => "oauths#callback" # これの必要性がいまいちピンと来てないので、後ほど調べてみて不要なら消す。今は参考記事に倣って記述してある。
   get "oauth/callback" => "oauths#callback"
   get "oauth/:provider" => "oauths#oauth", as: :auth_at_provider
 
+  resource :profile, only: %i[show]
+
+  resources :password_resets, only: %i[new create edit update]
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end


### PR DESCRIPTION
## 概要
ISSUE: #83

ユーザーのプロフィール表示機能、編集機能を実装しました

close #83 

## やったこと

- [x] 単数形リソースでプロフィールに関するルーティングを設定
- [x] `profiles_controller`の作成と、`show`, `edit`, `update`アクションの定義
- [x] プロフィール詳細画面(`profiles/new.html.erb`)と編集画面(`profiles/edit.html.erb`)の作成
- [x] プロフィール詳細画面へのリンクをヘッダーに追加

## やらないこと

- ユーザーの最寄駅の表示・編集機能の実装
  - 最寄駅のデータを扱う「滞在時間表示機能」の実装の際に、合わせて実装する。

## できるようになること（ユーザ目線）

- 自分のユーザー情報の閲覧と編集

## 動作確認

- ログイン後、ヘッダーの「プロフィール」をクリック 
  
- `/profile`に遷移し、ログイン中のユーザーのプロフィール情報が表示されることを確認  
[![Image from Gyazo](https://i.gyazo.com/0cb27f2eb33402d4722d33d3da5384d4.png)](https://gyazo.com/0cb27f2eb33402d4722d33d3da5384d4)  
  
- プロフィール表示画面で「編集」ボタンをクリック 
  
- `/profile/edit`に遷移し、編集フォームが表示されることを確認  
[![Image from Gyazo](https://i.gyazo.com/fbc3893978a7b4b21648fb25c5c7add3.png)](https://gyazo.com/fbc3893978a7b4b21648fb25c5c7add3)
  
-  入力フォームが空の状態で編集ボタンを押すと、バリデーションエラーが発生することを確認  
[![Image from Gyazo](https://i.gyazo.com/c54cb738b71615908f1da02e6bb9a8a2.png)](https://gyazo.com/c54cb738b71615908f1da02e6bb9a8a2)
  
- 適切にフォームに入力してから編集ボタンを押すと、プロフィール表示画面に遷移し、編集後の内容が表示されていることを確認。また、フラッシュメッセージが表示されることを確認  
[![Image from Gyazo](https://i.gyazo.com/93d5266d2c9b26a821579fb55f4e9448.png)](https://gyazo.com/93d5266d2c9b26a821579fb55f4e9448)
  
## 確認方法

1. ログイン後、ヘッダーの「プロフィール」をクリックすると`/profile`に遷移し、ログイン中のユーザーのユーザー名およびメールアドレスが表示されることを確認してください。
2. `/profile`の「編集」をクリックすると編集フォームが表示されることを確認してください。
3. フォームが空の状態で「編集」をクリックするとバリデーションエラーが発生することを確認してください。
4. 適切にフォームに入力して「編集」をクリックすると、`/profile`に遷移し、編集後の情報が表示されていることを確認してください。また、編集成功を示すフラッシュメッセージが表示されていることを確認してください。

## チェックリスト
- [x] Lint のチェックをパスした


## コメント, その他
- 現状ではプロフィール表示画面にはユーザー名及びメールアドレスのみを表示していますが、追加で最寄駅名も表示する予定です。最寄駅のデータを扱う「滞在時間表示機能」の実装の際に、合わせて最寄駅名の表示・編集機能を実装します。
- 現状ではプロフィール表示画面から編集画面へは別ページに遷移していますが、追ってSPA風のページにする予定です。Hotwireを用いて`/searches/result`など他のページをSPA風に修正していく際に、合わせて実装します。
