### PR TITLE
検索が実行されないバグの修正 

### DIFF
--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,7 +1,7 @@
 <div class="flex justify-center">
   <div class="w-full max-w-md px-4">
     <h1 class="text-2xl font-bold text-center mb-4">プロフィール編集</h1>
-    <%= form_with model: @user, url: profile_path, local: true do |f| %>
+    <%= form_with model: @user, url: profile_path do |f| %>
       <%= render 'shared/error_messages', object: @user %>
       <div class="mb-4">
         <%= f.label :name, class: 'block text-sm font-medium text-gray-700' %>

--- a/app/views/searches/new.html.erb
+++ b/app/views/searches/new.html.erb
@@ -1,4 +1,4 @@
-<%= form_with model: @user_selection, url: searches_path, local: true do |form| %>
+<%= form_with model: @user_selection, url: searches_path, data: { turbo: false } do |form| %>
   <%= render 'shared/error_messages', object: form.object %>
   <%= form.hidden_field :latitude, id: 'hidden_latitude' %>
   <%= form.hidden_field :longitude, id: 'hidden_longitude' %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -2,7 +2,7 @@
 <div class="flex justify-center">
   <div class="w-full max-w-md px-4">
     <h1 class="text-2xl font-bold text-center mb-4">ユーザー登録</h1>
-    <%= form_with model: @user, local: true do |f| %>
+    <%= form_with model: @user do |f| %>
       <div class="mb-4">
         <%= f.label :name, class: 'block text-sm font-medium text-gray-700' %>
         <%= f.text_field :name, class: 'mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm' %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,8 +1,8 @@
-<%= render 'shared/error_messages', object: @user %>
 <div class="flex justify-center">
   <div class="w-full max-w-md px-4">
     <h1 class="text-2xl font-bold text-center mb-4">ユーザー登録</h1>
     <%= form_with model: @user do |f| %>
+      <%= render 'shared/error_messages', object: @user %>
       <div class="mb-4">
         <%= f.label :name, class: 'block text-sm font-medium text-gray-700' %>
         <%= f.text_field :name, class: 'mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm' %>

--- a/app/views/usersessions/new.html.erb
+++ b/app/views/usersessions/new.html.erb
@@ -1,7 +1,7 @@
 <div class="flex justify-center">
   <div class="w-full max-w-md px-4">
     <h1 class="text-2xl font-bold text-center mb-4">ログイン</h1>
-    <%= form_with url: login_path, local: true do |f| %>
+    <%= form_with url: login_path do |f| %>
       <div class="mb-4">
         <%= f.label :email, class: 'block text-sm font-medium text-gray-700' %>
         <%= f.text_field :email, class: 'mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm' %>


### PR DESCRIPTION
## 概要
ISSUE: #111 

`searches/new`で条件を選択して検索ボタン押しても検索が実行されず画面遷移もしないバグを修正しました。

close #111 

## やったこと

- 検索条件をフォームで指定して送信する`searches/new.html.erb`の`form_with`ヘルパーに、`data: { turbo: false }`オプションを追加してTurboを無効化した。

## できるようになること（ユーザ目線）

- 検索条件の指定後に検索ボタンを押すと、結果表示画面(`searches.result`)に遷移して検索結果を閲覧できるようになる