### PR TITLE
ドライブ履歴保存機能

### DIFF
--- a/app/controllers/drive_records_controller.rb
+++ b/app/controllers/drive_records_controller.rb
@@ -1,11 +1,14 @@
 class DriveRecordsController < ApplicationController
   def create
+    # 目的地となる場所の特定と、その場所へのユーザーのドライブ履歴を生成するLogDestinationActivityServiceのcallメソッドを実行
     service = LogDestinationActivityService.new(
       current_user.id,
       destination_params,
       record_type: 'drive_record'
     )
-    service.call
+    if service.call
+      redirect_to root_path, flash: { success: "ドライブ履歴を保存しました" } # 処理後は仮でルートパスに遷移しているが、実際は経路案内を表示する画面に遷移させる。画面のUI/UXを整える過程で修正する。
+    end
   end
 
   private

--- a/app/controllers/drive_records_controller.rb
+++ b/app/controllers/drive_records_controller.rb
@@ -1,0 +1,16 @@
+class DriveRecordsController < ApplicationController
+  def create
+    service = LogDestinationActivityService.new(
+      current_user.id,
+      destination_params,
+      record_type: 'drive_record'
+    )
+    service.call
+  end
+
+  private
+
+  def destination_params
+    params.require(:destination).permit(:name, :address, :latitude, :longitude, :type)
+  end
+end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,3 +1,4 @@
 class Destination < ApplicationRecord
   belongs_to :google_places_api_type, optional: true
+  has_many :drive_records
 end

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -1,0 +1,3 @@
+class Destination < ApplicationRecord
+  belongs_to :google_places_api_type, optional: true
+end

--- a/app/models/drive_record.rb
+++ b/app/models/drive_record.rb
@@ -1,0 +1,4 @@
+class DriveRecord < ApplicationRecord
+  belongs_to :user
+  belongs_to :destination
+end

--- a/app/models/google_places_api_type.rb
+++ b/app/models/google_places_api_type.rb
@@ -1,6 +1,7 @@
 class GooglePlacesApiType < ApplicationRecord
   has_many :feeling_type_mappings, dependent: :destroy
   has_many :feelings, through: :feeling_type_mappings
+  has_many :destinations
 
   scope :by_feeling, lambda { |feeling_id|
     joins(:feeling_type_mappings)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   has_many :authentications, dependent: :destroy
   accepts_nested_attributes_for :authentications
 
+  has_many :drive_records, dependent: :destroy
+
   validates :password, length: { minimum: 6 }, if: -> { new_record? || changes[:crypted_password] }
   validates :password, confirmation: true, if: -> { new_record? || changes[:crypted_password] }
   validates :password_confirmation, presence: true, if: -> { new_record? || changes[:crypted_password] }

--- a/app/services/log_destination_activity_service.rb
+++ b/app/services/log_destination_activity_service.rb
@@ -1,12 +1,13 @@
 class LogDestinationActivityService
-  def initialize(user_id, destination_info, record_type:)
+  def initialize(user_id, destination_info, record_type:) # drive_recordsコントローラでこのサービスオブジェクトを呼び出す際に、引数の示す内容が不明瞭にならないようにする意図で、record_typeをキーワード引数(デフォルト値は無し)として定義している。
     @user = User.find(user_id)
     @destination_info = destination_info
     @record_type = record_type
   end
 
+  # 目的地となる場所の特定と、その場所へのユーザーのドライブ履歴を生成する処理
   def call
-    type = Type.find_by(name: @destination_info[:type])
+    type = GooglePlacesApiType.find_by(name: @destination_info[:type])
     destination = Destination.find_or_create_by(name: @destination_info[:name], address: @destination_info[:address], latitude: @destination_info[:latitude], longitude: @destination_info[:longitude], google_places_api_type: type)
     create_drive_record(destination)
   end
@@ -14,6 +15,6 @@ class LogDestinationActivityService
   private
 
   def create_drive_record(destination)
-    @user.drive_records.create(destination: destination)
+    @user.drive_records.create(destination: destination) # 基本的にはdrive_recordsレコードの保存処理の失敗は想定されないが、予期せぬ原因で失敗した場合の対応も追って記述しておく。
   end
 end

--- a/app/services/log_destination_activity_service.rb
+++ b/app/services/log_destination_activity_service.rb
@@ -1,0 +1,19 @@
+class LogDestinationActivityService
+  def initialize(user_id, destination_info, record_type:)
+    @user = User.find(user_id)
+    @destination_info = destination_info
+    @record_type = record_type
+  end
+
+  def call
+    type = Type.find_by(name: @destination_info[:type])
+    destination = Destination.find_or_create_by(name: @destination_info[:name], address: @destination_info[:address], latitude: @destination_info[:latitude], longitude: @destination_info[:longitude], google_places_api_type: type)
+    create_drive_record(destination)
+  end
+
+  private
+
+  def create_drive_record(destination)
+    @user.drive_records.create(destination: destination)
+  end
+end

--- a/app/services/search_places_service.rb
+++ b/app/services/search_places_service.rb
@@ -34,7 +34,7 @@ class SearchPlacesService
 
   def self.build_field_mask
     [
-      'places.types', 'places.addressComponents', 'places.location',
+      'places.types', 'places.formattedAddress', 'places.location',
       'places.rating', 'places.googleMapsUri', 'places.websiteUri',
       'places.businessStatus', 'places.userRatingCount',
       'places.displayName', 'places.currentOpeningHours',

--- a/app/views/searches/result.html.erb
+++ b/app/views/searches/result.html.erb
@@ -1,12 +1,21 @@
-<div class="text-center">
-  <h1 class="font-bold text-slate-600 text-3xl mb-8">検索結果</h1>
+<div>
+  <h1 class="text-center font-bold text-slate-600 text-3xl mb-8">検索結果</h1>
 </div>
 
-<div class="text-center">
-  <ul class="text-center flex flex-col items-center justify-center">
+<div>
+  <ul class="flex flex-col items-center justify-center">
     <% @response['places'].each do |place| %>
-      <li class= "flex bg-cyan-500 hover:bg-cyan-400 text-white font-bold py-3 px-6 rounded-full h-16 w-1/2 my-2">
-        <span class="flex items-center justify-center w-full"><%= place['displayName']['text'] %></span>
+      <li class= "flex flex-col space-y-2 bg-cyan-500 hover:bg-cyan-400 text-white font-bold py-3 px-6 rounded-full h-20 w-4/5 my-2">
+        <span class="flex justify-center text-center w-full"><%= place['displayName']['text'] %></span>
+        <%= link_to 'ここへ行く', drive_records_path(destination: {
+            name: place['displayName']['text'],
+            address: place['formattedAddress'],
+            latitude: place['location']['latitude'],
+            longitude: place['location']['longitude'],
+            type: place['primaryType']
+          }),
+          data: { turbo_method: :post },
+          class: "bg-teal-200 text-slate-600 text-center w-2/5 rounded-lg" %>
       </li>
     <% end %>
   </ul>

--- a/app/views/searches/result.html.erb
+++ b/app/views/searches/result.html.erb
@@ -7,15 +7,20 @@
     <% @response['places'].each do |place| %>
       <li class= "flex flex-col space-y-2 bg-cyan-500 hover:bg-cyan-400 text-white font-bold py-3 px-6 rounded-full h-20 w-4/5 my-2">
         <span class="flex justify-center text-center w-full"><%= place['displayName']['text'] %></span>
-        <%= link_to 'ここへ行く', drive_records_path(destination: {
-            name: place['displayName']['text'],
-            address: place['formattedAddress'],
-            latitude: place['location']['latitude'],
-            longitude: place['location']['longitude'],
-            type: place['primaryType']
-          }),
-          data: { turbo_method: :post },
-          class: "bg-teal-200 text-slate-600 text-center w-2/5 rounded-lg" %>
+        <!-- ユーザーのドライブ履歴作成処理のリクエストを送るリンクを仮で設置する。本来は、場所の詳細を表示するモーダル内に設置する経路案内のリンクに本リクエストを実装する -->
+        <!-- ドライブ履歴の保存はログインユーザーのみ利用できる機能であるため、ログイン状態でのみリンクを表示させる。 -->
+        <!-- ドライブ履歴作成処理では目的地となる場所を特定する必要があるため、当該場所の情報をパラメータに含めて送信する -->
+        <% if logged_in? %>
+          <%= link_to 'ここへ行く', drive_records_path(destination: {
+              name: place['displayName']['text'],
+              address: place['formattedAddress'],
+              latitude: place['location']['latitude'],
+              longitude: place['location']['longitude'],
+              type: place['primaryType']
+            }),
+            data: { turbo_method: :post },
+            class: "bg-teal-200 text-slate-600 text-center w-2/5 rounded-lg" %>
+        <% end %>
       </li>
     <% end %>
   </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,8 @@ Rails.application.routes.draw do
   get "oauth/:provider" => "oauths#oauth", as: :auth_at_provider
 
   resource :profile, only: %i[show edit update]
-
   resources :password_resets, only: %i[new create edit update]
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+
+  resources :drive_records, only: %i[create]
 end

--- a/db/migrate/20240108080739_create_destinations.rb
+++ b/db/migrate/20240108080739_create_destinations.rb
@@ -1,0 +1,14 @@
+class CreateDestinations < ActiveRecord::Migration[7.1]
+  def change
+    create_table :destinations do |t|
+      t.string :name
+      t.string :address
+      t.float :latitude
+      t.float :longitude
+      t.references :google_places_api_type, null: true, foreign_key: true
+      # google_places_api_typeを参照しないDestinationレコードも稀に存在すると想定されるため、外部キーがnullの場合でも許容する旨を明示的に記述している。
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20240108082114_create_drive_records.rb
+++ b/db/migrate/20240108082114_create_drive_records.rb
@@ -1,0 +1,10 @@
+class CreateDriveRecords < ActiveRecord::Migration[7.1]
+  def change
+    create_table :drive_records do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :destination, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_12_31_092808) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_08_082114) do
   create_table "authentications", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "provider", null: false
@@ -18,6 +18,26 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_31_092808) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["provider", "uid"], name: "index_authentications_on_provider_and_uid"
+  end
+
+  create_table "destinations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.string "name"
+    t.string "address"
+    t.float "latitude"
+    t.float "longitude"
+    t.bigint "google_places_api_type_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["google_places_api_type_id"], name: "index_destinations_on_google_places_api_type_id"
+  end
+
+  create_table "drive_records", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "destination_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["destination_id"], name: "index_drive_records_on_destination_id"
+    t.index ["user_id"], name: "index_drive_records_on_user_id"
   end
 
   create_table "feeling_type_mappings", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -59,4 +79,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_12_31_092808) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end
 
+  add_foreign_key "destinations", "google_places_api_types"
+  add_foreign_key "drive_records", "destinations"
+  add_foreign_key "drive_records", "users"
 end


### PR DESCRIPTION
## 概要

ISSUE: #105 

ログインユーザーのドライブ履歴を保存する機能を実装しました。

close #105 

## やったこと

- [x] 目的地となる場所の情報を扱うDestinationsテーブル作成
- [x] ドライブ履歴の情報を扱うDrive_recordsテーブル作成
- [x] 関連するDestinationsレコードの有無を確認してからDrive_recordsレコードを生成するサービスオブジェクトを作成
- [x] Drive_recordsコントローラ作成
  - createアクションの実装
- [x] Drive_records#createに対してドライブ履歴レコード作成のリクエストを送信するリンクをviewに実装

## やらないこと

- ドライブ履歴の一覧、詳細表示機能の実装

## できるようになること（ユーザ目線）

- ドライブを開始する際に、その場所へのドライブ履歴が保存される

## 動作確認

- ログインした状態で検索を実行し、結果表示画面('searches/result')に遷移する
- リスト形式で表示されている各場所の名称の下部に、「ここへ行く」という文字列のリンクが表示されていることを確認
- 「ここへ行く」を押すとトップページに遷移し、ドライブ履歴を保存した旨のフラッシュメッセージが表示されることを確認
- コンソールを開き、上記の確認作業で作成したドライブ履歴レコードが生成されていることを確認
- ログアウトした状態で検索を実行し、結果表示画面('searches/result')に遷移する
- リスト形式で表示されている各場所の名称の下部に、「ここへ行く」という文字列のリンクが表示されていないことを確認