### PR TITLE
検索結果表示ページ(searched/result)のUI実装

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -22,3 +22,8 @@
 .max-h-screen {
   max-height: 100vh; /* ビューポートの高さに合わせる */
 }
+
+/* app/views/searches/new.html.erbで、表示中のカルーセルアイテムのインジケーターに色を付けるためのスタイル */
+.active-indicator {
+  background-color: #94a3b8
+}

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -18,6 +18,7 @@ class SearchesController < ApplicationController
 
   def result
     @response = SearchPlacesService.search_places(session[:request_params])
+    @user_selection = UserSelectionForm.new
   end
 
   private

--- a/app/services/search_places_service.rb
+++ b/app/services/search_places_service.rb
@@ -20,7 +20,8 @@ class SearchPlacesService
           radius: params['radius']
         }
       },
-      languageCode: 'ja'
+      languageCode: 'ja',
+      maxResultCount: 10
     }
 
     http = Net::HTTP.new(uri.host, uri.port) # Google Places APIへのリクエストを実行するHTTPクライアントを作成

--- a/app/views/destinations/_bookmark.html.erb
+++ b/app/views/destinations/_bookmark.html.erb
@@ -7,6 +7,6 @@
     longitude: place['location']['longitude'],
     type: place['primaryType']
   }), 
-  data: { turbo_method: :post },
-  class: "p-1 rounded-lg border-2 border-slate-300" %>
+  data: { turbo_method: :post }
+  %>
   

--- a/app/views/destinations/_unbookmark.html.erb
+++ b/app/views/destinations/_unbookmark.html.erb
@@ -5,5 +5,5 @@
       address: place['formattedAddress']
     )
   ), 
-data: { turbo_method: :delete },
-class: "p-1 rounded-lg border-2 border-slate-300" %>
+data: { turbo_method: :delete }
+%>

--- a/app/views/destinations/bookmarks.html.erb
+++ b/app/views/destinations/bookmarks.html.erb
@@ -6,10 +6,10 @@
     <div>
       <%= render 'shared/search_form', q: @q, url: bookmarks_destinations_path %>
     </div>
-    <div class="bg-blue-100 rounded-3xl py-5 mx-5 flex flex-col items-center justify-center text-slate-600">
+    <div class="bg-orange-100 rounded-3xl py-5 mx-5 flex flex-col items-center justify-center text-slate-600">
       <% if @bookmark_destinations.present? %>
         <% @bookmark_destinations.each do |bookmark_destination| %>
-          <div class= "hover:bg-blue-300 font-bold rounded-sm border-b-2 border-slate-400 h-20 w-4/5 my-1 px-3">
+          <div class= "hover:bg-orange-300 font-bold rounded-sm border-b-2 border-slate-400 h-20 w-4/5 my-1 px-3">
             <%= link_to destination_path(bookmark_destination), class: "flex flex-col space-y-2 justify-center text-center w-full" do %>
               <span class="pt-2"><%= bookmark_destination.name %></span>
               <span class="text-xs"><%= bookmark_destination.address %></span>

--- a/app/views/destinations/show.html.erb
+++ b/app/views/destinations/show.html.erb
@@ -1,7 +1,7 @@
 <div>
   <h1 class="text-center font-bold text-slate-600 text-3xl mb-8">ブックマーク詳細</h1>
 </div>
-<div class="bg-blue-100 rounded-3xl p-5 mx-5 flex flex-col items-center text-slate-600 font-bold h-96">
+<div class="bg-orange-100 rounded-3xl p-5 mx-5 flex flex-col items-center text-slate-600 font-bold h-96">
   <h2 class="text-xl p-3"><%= @bookmark_destination.name %></h2>
   <p class="text-sm"><%= @bookmark_destination.address %></p>
 </div>

--- a/app/views/drive_records/index.html.erb
+++ b/app/views/drive_records/index.html.erb
@@ -6,10 +6,10 @@
     <div>
       <%= render 'shared/search_form', q: @q, url: drive_records_path %>
     </div>
-    <div class="bg-blue-100 rounded-3xl py-5 mx-5 flex flex-col items-center justify-center text-slate-600">
+    <div class="bg-orange-100 rounded-3xl py-5 mx-5 flex flex-col items-center justify-center text-slate-600">
       <% if @drive_records.present? %>
         <% @drive_records.each do |drive_record| %>
-          <div class= "hover:bg-blue-300 font-bold rounded-sm border-b-2 border-slate-400 h-20 w-4/5 my-1 px-3">
+          <div class= "hover:bg-orange-300 font-bold rounded-sm border-b-2 border-slate-400 h-20 w-4/5 my-1 px-3">
             <%= link_to drive_record_path(drive_record), class: "flex flex-col space-y-2 justify-center text-center w-full" do%>
               <span class="pt-2"><%= drive_record.destination.name %></span>
               <span class="text-xs"><%= drive_record.destination.address %></span>

--- a/app/views/drive_records/show.html.erb
+++ b/app/views/drive_records/show.html.erb
@@ -1,7 +1,7 @@
 <div>
   <h1 class="text-center font-bold text-slate-600 text-3xl mb-8">ドライブ履歴詳細</h1>
 </div>
-<div class="bg-blue-100 rounded-3xl p-5 mx-5 flex flex-col items-center text-slate-600 font-bold h-96">
+<div class="bg-orange-100 rounded-3xl p-5 mx-5 flex flex-col items-center text-slate-600 font-bold h-96">
   <h2 class="text-xl p-3"><%= @drive_record_destination.name %></h2>
   <p class="text-sm"><%= @drive_record_destination.address %></p>
   <p class="py-5">日付: <%= @drive_record_destination.created_at %></p>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,7 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
-    <div class="bg-cyan-50 flex-grow">
+    <div class="bg-gray-100 flex-grow">
       <main class="container mx-auto my-8">
         <%= render 'shared/flash_message' %>
         <%= yield %>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -21,7 +21,7 @@
       </tr>
     </table>
     <div class='text-center mt-4'>
-      <%= link_to '編集', edit_profile_path, class: 'text-indigo-600 hover:text-indigo-500' %>
+      <%= link_to '編集', edit_profile_path, class: "py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-orange-500 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500" %>
     </div>
   </div>
 </div>

--- a/app/views/searches/new.html.erb
+++ b/app/views/searches/new.html.erb
@@ -1,5 +1,5 @@
 <div class="flex justify-center items-center mx-auto">
-  <%= button_tag '行き先を探す', type: 'button', id: 'toggle-form-button', class: 'bg-cyan-500 hover:bg-cyan-400 text-lg text-white font-bold py-3 px-6 rounded-full my-4' %>
+  <%= button_tag '行き先を探す', type: 'button', id: 'toggle-form-button', class: 'bg-orange-400 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 text-lg text-white font-bold py-3 px-6 rounded-lg my-4' %>
 </div>
 
 <div id="search-form" class="transition-all ease-in-out duration-500 max-h-0 overflow-hidden m-5">
@@ -11,7 +11,7 @@
     <div class="flex flex-row justify-center items-center space-x-4">
       <!-- ドロップダウンを開くボタン (カテゴリ) の親要素 -->
       <div class="form-element">
-        <%= button_tag type: 'button', id: 'dropdownSearchButton', class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800', data: { dropdown_toggle: 'dropdownSearch' } do %>
+        <%= button_tag type: 'button', id: 'dropdownSearchButton', class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white rounded-lg bg-orange-400 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500', data: { dropdown_toggle: 'dropdownSearch' } do %>
           カテゴリ
           <%= content_tag :svg, class: 'w-2.5 h-2.5 ms-2.5', aria: { hidden: true }, xmlns: 'http://www.w3.org/2000/svg', fill: 'none', viewBox: '0 0 10 6' do %>
             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
@@ -34,7 +34,7 @@
 
       <!-- ドロップダウンを開くボタン (気分) -->
       <div class="form-element">
-        <%= button_tag type: 'button', id: 'dropdownFeelingButton', class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white bg-blue-700 rounded-lg hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800', data: { dropdown_toggle: 'dropdownFeeling' } do %>
+        <%= button_tag type: 'button', id: 'dropdownFeelingButton', class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white rounded-lg bg-orange-400 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500', data: { dropdown_toggle: 'dropdownFeeling' } do %>
           気分
           <%= content_tag :svg, class: 'w-2.5 h-2.5 ms-2.5', aria: { hidden: true }, xmlns: 'http://www.w3.org/2000/svg', fill: 'none', viewBox: '0 0 10 6' do %>
             <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
@@ -57,12 +57,12 @@
 
       <!-- 運転範囲の選択 -->
       <div class="form-element">
-        <%= form.select :drive_range, options_for_select(@user_selection.drive_time_options), { include_blank: '選択してください' }, class: "form-select block w-60 rounded-md shadow-sm bg-white border-2 border-indigo-300 hover:border-indigo-500 focus:border-indigo-400 focus:ring focus:ring-indigo-200 focus:ring-opacity-50 " %>
+        <%= form.select :drive_range, options_for_select(@user_selection.drive_time_options), { include_blank: '選択してください' }, class: "form-select block w-60 rounded-md shadow-sm bg-white border-2 border-orange-300 hover:border-orange-500 focus:border-orange-400 focus:ring focus:ring-orange-200 focus:ring-opacity-50 " %>
       </div>
 
       <!-- 検索ボタン -->
       <div class="form-element">
-        <%= form.submit '検索', class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
+        <%= form.submit '検索', class: "bg-orange-500 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 text-white font-bold py-2 px-4 rounded" %>
       </div>
     </div>
   <% end %>

--- a/app/views/searches/new.html.erb
+++ b/app/views/searches/new.html.erb
@@ -3,69 +3,7 @@
 </div>
 
 <div id="search-form" class="transition-all ease-in-out duration-500 max-h-0 overflow-hidden m-5">
-  <%= form_with model: @user_selection, url: searches_path, data: { turbo: false } do |form| %>
-    <%= render 'shared/error_messages', object: form.object %>
-    <%= form.hidden_field :latitude, id: 'hidden_latitude' %>
-    <%= form.hidden_field :longitude, id: 'hidden_longitude' %>
-
-    <div class="flex flex-row justify-center items-center space-x-4">
-      <!-- ドロップダウンを開くボタン (カテゴリ) の親要素 -->
-      <div class="form-element">
-        <%= button_tag type: 'button', id: 'dropdownSearchButton', class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white rounded-lg bg-orange-400 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500', data: { dropdown_toggle: 'dropdownSearch' } do %>
-          カテゴリ
-          <%= content_tag :svg, class: 'w-2.5 h-2.5 ms-2.5', aria: { hidden: true }, xmlns: 'http://www.w3.org/2000/svg', fill: 'none', viewBox: '0 0 10 6' do %>
-            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
-          <% end %>
-        <% end %>
-        <!-- ドロップダウンのコンテンツ (カテゴリ) -->
-        <div id="dropdownSearch" class="z-10 hidden bg-white rounded-lg shadow w-60 dark:bg-gray-700">
-          <ul class="h-48 px-3 pb-3 overflow-y-auto text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownSearchButton">
-            <div class="form-element space-y-2 flex flex-col justify-center">
-              <%= form.collection_check_boxes :type, GooglePlacesApiType.all, :name, :display_name, include_hidden: false do |b| %>
-                <div class="flex items-center">
-                  <%= b.check_box(class: "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600") %>
-                  <%= b.label(class: "ms-2 text-sm font-medium text-gray-900 dark:text-gray-300") %>
-                </div>
-              <% end %>
-            </div>
-          </ul>
-        </div>
-      </div>
-
-      <!-- ドロップダウンを開くボタン (気分) -->
-      <div class="form-element">
-        <%= button_tag type: 'button', id: 'dropdownFeelingButton', class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white rounded-lg bg-orange-400 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500', data: { dropdown_toggle: 'dropdownFeeling' } do %>
-          気分
-          <%= content_tag :svg, class: 'w-2.5 h-2.5 ms-2.5', aria: { hidden: true }, xmlns: 'http://www.w3.org/2000/svg', fill: 'none', viewBox: '0 0 10 6' do %>
-            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
-          <% end %>
-        <% end %>
-        <!-- ドロップダウンのコンテンツ (気分) -->
-        <div id="dropdownFeeling" class="z-10 hidden bg-white rounded-lg shadow w-60 dark:bg-gray-700">
-          <ul class="px-3 pb-3 overflow-y-auto text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownFeelingButton">
-            <div class="form-element space-y-2">
-              <%= form.collection_radio_buttons :feeling, Feeling.all, :id, :name do |b| %>
-                <div class="flex items-center">
-                  <%= b.radio_button(class: "form-radio hidden") %>
-                  <%= b.label(class: "ms-2 text-sm font-medium text-gray-900 dark:text-gray-300") %>
-                </div>
-              <% end %>
-            </div>
-          </ul>
-        </div>
-      </div>
-
-      <!-- 運転範囲の選択 -->
-      <div class="form-element">
-        <%= form.select :drive_range, options_for_select(@user_selection.drive_time_options), { include_blank: '選択してください' }, class: "form-select block w-60 rounded-md shadow-sm bg-white border-2 border-orange-300 hover:border-orange-500 focus:border-orange-400 focus:ring focus:ring-orange-200 focus:ring-opacity-50 " %>
-      </div>
-
-      <!-- 検索ボタン -->
-      <div class="form-element">
-        <%= form.submit '検索', class: "bg-orange-500 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 text-white font-bold py-2 px-4 rounded" %>
-      </div>
-    </div>
-  <% end %>
+  <%= render 'shared/search_place_form' %>
 </div>
 
 <script>
@@ -90,6 +28,9 @@
           document.getElementById('hidden_latitude').value = position.coords.latitude;
           document.getElementById('hidden_longitude').value = position.coords.longitude;
 
+          sessionStorage.setItem('latitude', position.coords.latitude); // 検索結果表示画面(searches/result)の検索フォームにも、取得した緯度と経度の情報を渡す必要があるため、ブラウザのセッションストレージに格納しておく。
+          sessionStorage.setItem('longitude', position.coords.longitude);
+
           // 位置情報の取得後、フォームを表示
           showForm(searchForm);
         }, (error) => {
@@ -112,22 +53,4 @@
       formElement.classList.remove('max-h-screen');
     }
   }
-
-  document.addEventListener('DOMContentLoaded', () => {
-    // カテゴリのドロップダウン制御
-    const dropdownSearchButton = document.getElementById('dropdownSearchButton');
-    const dropdownSearchContent = document.getElementById('dropdownSearch');
-
-    dropdownSearchButton.addEventListener('click', () => {
-      dropdownSearchContent.classList.toggle('hidden');
-    });
-
-    // 気分のドロップダウン制御
-    const dropdownFeelingButton = document.getElementById('dropdownFeelingButton');
-    const dropdownFeelingContent = document.getElementById('dropdownFeeling');
-
-    dropdownFeelingButton.addEventListener('click', () => {
-      dropdownFeelingContent.classList.toggle('hidden');
-    });
-  });
 </script>

--- a/app/views/searches/result.html.erb
+++ b/app/views/searches/result.html.erb
@@ -9,27 +9,27 @@
       <% @response['places'].each_with_index do |place, index| %>
         <!-- カルーセル内の個々のアイテム -->
         <div class="<%= 'hidden' unless index.zero? %> duration-700 ease-in-out h-full" data-carousel-item>
-            <div class="bg-blue-100 rounded-3xl py-5 mx-5 h-full flex flex-col items-center justify-center text-slate-600 font-bold">
-                <div class="px-6 rounded-sm border-b-2 border-slate-400 h-20 w-4/5 my-2">
-                    <span class="flex justify-center text-center w-full mb-2"><%= place['displayName']['text'] %></span>
-                    <div class="flex justify-around items-center w-full">
-                        <% if logged_in? %>
-                            <%= link_to 'ここへ行く', drive_records_path(destination: {
-                                name: place['displayName']['text'],
-                                address: place['formattedAddress'],
-                                top_level_area: place["addressComponents"].find { |component| component["types"].include?("administrative_area_level_1") }["longText"],
-                                second_level_area: place["addressComponents"].find { |component| component["types"].include?("administrative_area_level_2") || component["types"].include?("locality") }["longText"],
-                                latitude: place['location']['latitude'],
-                                longitude: place['location']['longitude'],
-                                type: place['primaryType']
-                            }),
-                            data: { turbo_method: :post },
-                            class: "p-1 rounded-lg border-2 border-slate-300" %>
-                            <%= render 'destinations/bookmark_button', place: place %>
-                        <% end %>
-                    </div>
-                </div>
+          <div class="bg-blue-100 rounded-3xl py-5 mx-5 h-full flex flex-col items-center justify-center text-slate-600 font-bold">
+            <div class="px-6 rounded-sm border-b-2 border-slate-400 h-20 w-4/5 my-2">
+              <span class="flex justify-center text-center w-full mb-2"><%= place['displayName']['text'] %></span>
+              <div class="flex justify-around items-center w-full">
+                <% if logged_in? %>
+                  <%= link_to 'ここへ行く', drive_records_path(destination: {
+                      name: place['displayName']['text'],
+                      address: place['formattedAddress'],
+                      top_level_area: place["addressComponents"].find { |component| component["types"].include?("administrative_area_level_1") }["longText"],
+                      second_level_area: place["addressComponents"].find { |component| component["types"].include?("administrative_area_level_2") || component["types"].include?("locality") }["longText"],
+                      latitude: place['location']['latitude'],
+                      longitude: place['location']['longitude'],
+                      type: place['primaryType']
+                  }),
+                  data: { turbo_method: :post },
+                  class: "p-1 rounded-lg border-2 border-slate-300" %>
+                  <%= render 'destinations/bookmark_button', place: place %>
+                <% end %>
+              </div>
             </div>
+          </div>
         </div>
       <% end %>
 
@@ -66,6 +66,7 @@
 <script>
   // Searches#resultから受け取った各場所のデータ(@response['places'])を変数に格納
   const places = <%= @response['places'].to_json.html_safe %>;
+  let markers = []; // マーカーを格納する配列
 
   function initMap() {
     // ブラウザのセッションストレージから現在地の緯度と経度を取得
@@ -95,7 +96,9 @@
       const marker = new google.maps.Marker({
         position: markerPosition,
         map: map,
+        visible: false, // 初期状態では非表示に設定
       });
+      markers.push(marker);
 
       // 情報ウィンドウ内部の、Googleマップでのルート検索リンク(「ルート検索 (Google Map)」)には、現在地を取得するクリックイベントを設定している。
       // このクリックイベント実行のために、それぞれのルート検索リンクには動的な一意のIDを付与する必要があるため、以下で生成する。
@@ -158,6 +161,15 @@
         });
       })
     });
+    // 初期表示するカルーセルアイテムに対応するマーカーを表示
+    updateMarkers(0);
+  }
+
+  // 指定されたインデックスのカルーセルアイテムに対応するマーカーを表示する関数
+  function updateMarkers(index) {
+    markers.forEach((marker, i) => {
+      marker.setVisible(i === index); // 現在のアイテムに対応するマーカーのみを表示
+    });
   }
 
   document.addEventListener('DOMContentLoaded', () => {
@@ -172,7 +184,6 @@
     function updateIndicators(newIndex) {
       // 現在アクティブなインジケーターのクラスを削除
       indicators[currentIndex].classList.remove('active-indicator');
-
       // 新しいインジケーターにアクティブクラスを追加
       indicators[newIndex].classList.add('active-indicator');
     }
@@ -187,6 +198,7 @@
       items[currentIndex].classList.add('hidden'); // 現在のアイテムを非表示
       items[index].classList.remove('hidden'); // 新しいアイテムを表示
       updateIndicators(index); // インジケーターの更新
+      updateMarkers(index); // マーカーの表示を更新
       currentIndex = index; // 現在のインデックスを更新
     }
 

--- a/app/views/searches/result.html.erb
+++ b/app/views/searches/result.html.erb
@@ -1,5 +1,5 @@
 <div>
-  <h1 class="text-center font-bold text-slate-600 text-3xl mb-8">検索結果</h1>
+  <%= render 'shared/search_place_form' %>
 </div>
 
 <div class="flex justify-center">
@@ -13,6 +13,9 @@
             <div class="h-full w-4/5 my-2 px-6">
               <span class="flex justify-center text-center w-full mb-2"><%= place['displayName']['text'] %></span>
               <div class="flex flex-col space-y-2 items-center w-full">
+                <%= link_to '公式サイト', place['websiteUri'], target: '_blank', rel: 'noopener noreferrer' %>
+                <%= link_to 'ルート検索 (Yahoo!カーナビ)', "yjcarnavi://navi/select?lat=#{place['location']['latitude']}&lon=#{place['location']['longitude']}" %>
+                <%= link_to 'ルート検索 (Google Map)', '#', class: 'google-map-link', data: { lat: place['location']['latitude'], lng: place['location']['longitude'] } %>
                 <% if logged_in? %>
                   <%= link_to 'ここへ行く', drive_records_path(destination: {
                       name: place['displayName']['text'],
@@ -25,9 +28,6 @@
                   }),
                   data: { turbo_method: :post }
                   %>
-                  <%= link_to '公式サイト', place['websiteUri'], target: '_blank', rel: 'noopener noreferrer' %>
-                  <%= link_to 'ルート検索 (Yahoo!カーナビ)', "yjcarnavi://navi/select?lat=#{place['location']['latitude']}&lon=#{place['location']['longitude']}" %>
-                  <%= link_to 'ルート検索 (Google Map)', '#', class: 'google-map-link', data: { lat: place['location']['latitude'], lng: place['location']['longitude'] } %>
                   <%= render 'destinations/bookmark_button', place: place %>
                 <% end %>
               </div>
@@ -63,6 +63,17 @@
 </div> 
 
 <script>
+  // ページのDOM要素が全て読み込まれたら、ブラウザのセッションストレージに格納されている緯度と経度のデータを取得し、上記フォーム内の該当するhidden_fieldに設定する処理
+  // 現在地の緯度と経度のデータは、ユーザーがフォームで選択した内容とまとめてコントローラに送って処理したいため、hidden_fieldに設定する
+  document.addEventListener('DOMContentLoaded', (event) => {
+  const latitude = sessionStorage.getItem('latitude');
+  const longitude = sessionStorage.getItem('longitude');
+
+  document.getElementById('hidden_latitude').value = latitude;
+  document.getElementById('hidden_longitude').value = longitude;
+  });
+
+
   // Searches#resultから受け取った各場所のデータ(@response['places'])を変数に格納
   const places = <%= @response['places'].to_json.html_safe %>;
   let markers = []; // マーカーを格納する配列

--- a/app/views/searches/result.html.erb
+++ b/app/views/searches/result.html.erb
@@ -5,14 +5,14 @@
 <div class="flex justify-center">
   <div id="default-carousel" class="relative w-full p-5" data-carousel="slide">
     <!-- カルーセルのラッパー -->
-    <div class="relative h-56 overflow-hidden rounded-lg md:h-96">
+    <div class="relative h-96 overflow-hidden rounded-lg md:h-96">
       <% @response['places'].each_with_index do |place, index| %>
         <!-- カルーセル内の個々のアイテム -->
         <div class="<%= 'hidden' unless index.zero? %> duration-700 ease-in-out h-full" data-carousel-item>
-          <div class="bg-blue-100 rounded-3xl py-5 mx-5 h-full flex flex-col items-center justify-center text-slate-600 font-bold">
-            <div class="px-6 rounded-sm border-b-2 border-slate-400 h-20 w-4/5 my-2">
+          <div class="bg-blue-100 rounded-3xl py-5 mx-5 h-full flex flex-col items-center text-slate-600 font-bold">
+            <div class="h-full w-4/5 my-2 px-6">
               <span class="flex justify-center text-center w-full mb-2"><%= place['displayName']['text'] %></span>
-              <div class="flex justify-around items-center w-full">
+              <div class="flex flex-col space-y-2 items-center w-full">
                 <% if logged_in? %>
                   <%= link_to 'ここへ行く', drive_records_path(destination: {
                       name: place['displayName']['text'],
@@ -23,8 +23,11 @@
                       longitude: place['location']['longitude'],
                       type: place['primaryType']
                   }),
-                  data: { turbo_method: :post },
-                  class: "p-1 rounded-lg border-2 border-slate-300" %>
+                  data: { turbo_method: :post }
+                  %>
+                  <%= link_to '公式サイト', place['websiteUri'], target: '_blank', rel: 'noopener noreferrer' %>
+                  <%= link_to 'ルート検索 (Yahoo!カーナビ)', "yjcarnavi://navi/select?lat=#{place['location']['latitude']}&lon=#{place['location']['longitude']}" %>
+                  <%= link_to 'ルート検索 (Google Map)', '#', class: 'google-map-link', data: { lat: place['location']['latitude'], lng: place['location']['longitude'] } %>
                   <%= render 'destinations/bookmark_button', place: place %>
                 <% end %>
               </div>
@@ -56,12 +59,8 @@
 
 <!-- マップの表示領域となる要素を定義。 -->
 <div class="flex justify-center items-center">
-  <div id="map" class="h-72 w-96 my-5"></div>
+  <div id="map" class="h-64 w-96"></div>
 </div> 
-
-<div class="text-center my-5">
-  <p><%= link_to 'トップへ戻る', root_path, class: "bg-gray-500 hover:bg-gray-700 text-white font-bold py-2 px-4 rounded w-1/4 my-2" %></p>
-</div>
 
 <script>
   // Searches#resultから受け取った各場所のデータ(@response['places'])を変数に格納
@@ -82,8 +81,6 @@
       center: mapCenter
     });
 
-    let openInfoWindow = null; // 現在開いている情報ウィンドウを変数で管理
-
     // 検索結果として表示する各場所に対して繰り返し処理を定義し、マーカーを作成
     // 繰り返し処理の中で各マーカーに紐づく情報ウィンドウも作成し、マーカークリック時に表示されるようイベントハンドラを定義
     places.forEach(function(place) {
@@ -99,68 +96,7 @@
         visible: false, // 初期状態では非表示に設定
       });
       markers.push(marker);
-
-      // 情報ウィンドウ内部の、Googleマップでのルート検索リンク(「ルート検索 (Google Map)」)には、現在地を取得するクリックイベントを設定している。
-      // このクリックイベント実行のために、それぞれのルート検索リンクには動的な一意のIDを付与する必要があるため、以下で生成する。
-      const uniqueId = `googleMapsLink-${place['location']['latitude']}-${place['location']['longitude']}`;
-
-      // 情報ウィンドウの表示内容を定義
-      const infowindowContent = `
-        <div class="text-center">
-        <h1 class="font-bold">${place['displayName']['text']}</h1>
-        <div>
-        <p>${place['primaryType']}</p>
-        <p><a href="${place['websiteUri']}" target="_blank" rel="noopener noreferrer">サイトURL</a></p>
-        <p><a href="yjcarnavi://navi/select?lat=${place['location']['latitude']}&lon=${place['location']['longitude']}">ルート検索 (Yahoo!カーナビ)</a></p>
-        <p><a href="#" id="${uniqueId}" data-lat="${place['location']['latitude']}" data-lng="${place['location']['longitude']}">ルート検索 (Google Map)</a></p>
-        </div>
-        </div>`
-      // ナビ起動リンク押されたとき、外部サービスに位置情報を共有する旨のアラート出す方が良いかも。
-      // 走行中にルート検索をする場合、移動によって、ルート検索時の緯度経度は検索時に取得した緯度経度から若干変わっている可能性がある。
-      // そのため、以下でルート探索のリンクにクリックイベントを設定(googleMapsLink.addEventListener)して、改めて緯度と経度を取得した上でルート検索を実行している。
-      // Yahoo!カーナビの方は、リンクをクリックしてアプリに遷移すると、自動的にルート探索時の現在地が出発地点として設定される。そのため、本アプリでの現在地取得は不要。
-
-      // 上部で定義した表示内容を用いて、情報ウィンドウオブジェクトを作成
-      const infowindow = new google.maps.InfoWindow({
-        content: infowindowContent
-      })
-
-      marker.addListener('click', () => {
-        // マーカーがクリックされた際、既に開いている情報ウィンドウがあれば閉じる
-        if (openInfoWindow) {
-          openInfoWindow.close();
-        }
-        infowindow.open({
-          anchor: marker,
-          map: map
-        });
-        openInfoWindow = infowindow // 開いた情報ウィンドウを変数に入れて管理
-
-        // 以下で、情報ウィンドウ内の、Googleマップでのルート検索リンクのクリックイベントを定義
-        // Googleマップでのルート検索リンク(uniqueIdをidにもつ要素)は、infowindowのcontentに指定されているinfowindowContent内にある。infowindowContentはinfowindow.openで情報ウィンドウが開かれたタイミングで、要素としてDOMに追加される。
-        // しかし実際の動作では、DOMの変更は非同期で行われることも多く、infowindow.openの実行後ただちにinfowindowContentがDOMに追加されるとは限らない。infowindowContentがDOM要素に追加された後にgetElementByIdで要素を確実に取得するため、Maps JavaScript APIのInfoWindowオブジェクトに定義されているdomreadyイベントを利用したイベントリスナーを設定する。
-        google.maps.event.addListenerOnce(infowindow, 'domready', () => {
-          const googleMapsLink = document.getElementById(uniqueId);
-          googleMapsLink.addEventListener('click', (event) => {
-            event.preventDefault();
-            const destinationLat = event.currentTarget.getAttribute('data-lat'); // イベントに関連する多くの情報を含むeventオブジェクトのcurrentTargetプロパティ(ここでは、id: googleMapsLink が設定されたaタグの要素)のgetAttributeメソッドを実行している
-            const destinationLng = event.currentTarget.getAttribute('data-lng');
-
-            // ユーザーの現在地を改めて取得
-            navigator.geolocation.getCurrentPosition((position) => {
-              const originLat = position.coords.latitude;
-              const originLng = position.coords.longitude;
-
-              // Googleマップのルート探索URLを生成し、別タブで開く
-              const googleMapsUri = `https://www.google.com/maps/dir/?api=1&origin=${originLat},${originLng}&destination=${destinationLat},${destinationLng}`;
-              window.open(googleMapsUri, '_blank', 'noopener,noreferrer');
-            }, (error) => {
-              alert('現在地を取得できませんでした。');
-            });
-          });
-        });
-      })
-    });
+    })
     // 初期表示するカルーセルアイテムに対応するマーカーを表示
     updateMarkers(0);
   }
@@ -222,6 +158,34 @@
 
     // 初期状態で最初のアイテムのインジケーターをアクティブにする
     updateIndicators(0);
+  });
+
+  // ページが読み込まれた後に実行されるイベントリスナー
+  document.addEventListener('DOMContentLoaded', () => {
+    // クラス名 'google-map-link' を持つすべてのリンクを取得
+    const googleMapLinks = document.querySelectorAll('.google-map-link')
+    // 各リンクにイベントリスナーを設定
+    googleMapLinks.forEach(link => {
+      link.addEventListener('click', (event) => {
+        // デフォルトのアクション（リンクの遷移）を防止
+        event.preventDefault()
+        // クリックされたリンクから目的地の緯度と経度を取得
+        const destinationLat = event.currentTarget.getAttribute('data-lat');
+        const destinationLng = event.currentTarget.getAttribute('data-lng')
+        // ユーザーの現在地を取得
+        navigator.geolocation.getCurrentPosition((position) => {
+          // 現在地の緯度と経度を取得
+          const originLat = position.coords.latitude;
+          const originLng = position.coords.longitude
+          // Googleマップのルート探索URLを生成し、新しいタブで開く
+          const googleMapsUri = `https://www.google.com/maps/dir/?api=1&origin=${originLat},${originLng}&destination=${destinationLat},${destinationLng}`;
+          window.open(googleMapsUri, '_blank', 'noopener,noreferrer');
+        }, (error) => {
+          // 現在地の取得に失敗した場合のエラーハンドリング
+          alert('現在地を取得できませんでした。');
+        });
+      });
+    });
   });
 </script>
 

--- a/app/views/searches/result.html.erb
+++ b/app/views/searches/result.html.erb
@@ -2,33 +2,56 @@
   <h1 class="text-center font-bold text-slate-600 text-3xl mb-8">検索結果</h1>
 </div>
 
-<div class="bg-blue-100 rounded-3xl py-5 mx-5">
-  <ul class="flex flex-col items-center justify-center text-slate-600">
-    <% @response['places'].each do |place| %>
-      <li class= "flex flex-col font-bold px-6 rounded-sm border-b-2 border-slate-400 h-20 w-4/5 my-2">
-        <span class="flex justify-center text-center w-full mb-2"><%= place['displayName']['text'] %></span>
-        <div class="flex justify-around items-center w-full">
-          <% if logged_in? %>
-            <!-- ユーザーのドライブ履歴作成処理のリクエストを送るリンクを仮で設置する。本来は、場所の詳細を表示するモーダル内に設置する経路案内のリンクに本リクエストを実装する -->
-            <!-- ドライブ履歴の保存はログインユーザーのみ利用できる機能であるため、ログイン状態でのみリンクを表示させる。 -->
-            <!-- ドライブ履歴作成処理では目的地となる場所を特定する必要があるため、当該場所の情報をパラメータに含めて送信する -->
-            <%= link_to 'ここへ行く', drive_records_path(destination: {
-                name: place['displayName']['text'],
-                address: place['formattedAddress'],
-                top_level_area: place["addressComponents"].find { |component| component["types"].include?("administrative_area_level_1") }["longText"],
-                second_level_area: place["addressComponents"].find { |component| component["types"].include?("administrative_area_level_2") || component["types"].include?("locality") }["longText"],
-                latitude: place['location']['latitude'],
-                longitude: place['location']['longitude'],
-                type: place['primaryType']
-              }),
-              data: { turbo_method: :post },
-              class: "p-1 rounded-lg border-2 border-slate-300" %>
-            <%= render 'destinations/bookmark_button', place: place %>
-          <% end %>
+<div class="flex justify-center">
+  <div id="default-carousel" class="relative w-full p-5" data-carousel="slide">
+    <!-- カルーセルのラッパー -->
+    <div class="relative h-56 overflow-hidden rounded-lg md:h-96">
+      <% @response['places'].each_with_index do |place, index| %>
+        <!-- カルーセル内の個々のアイテム -->
+        <div class="<%= 'hidden' unless index.zero? %> duration-700 ease-in-out h-full" data-carousel-item>
+            <div class="bg-blue-100 rounded-3xl py-5 mx-5 h-full flex flex-col items-center justify-center text-slate-600 font-bold">
+                <div class="px-6 rounded-sm border-b-2 border-slate-400 h-20 w-4/5 my-2">
+                    <span class="flex justify-center text-center w-full mb-2"><%= place['displayName']['text'] %></span>
+                    <div class="flex justify-around items-center w-full">
+                        <% if logged_in? %>
+                            <%= link_to 'ここへ行く', drive_records_path(destination: {
+                                name: place['displayName']['text'],
+                                address: place['formattedAddress'],
+                                top_level_area: place["addressComponents"].find { |component| component["types"].include?("administrative_area_level_1") }["longText"],
+                                second_level_area: place["addressComponents"].find { |component| component["types"].include?("administrative_area_level_2") || component["types"].include?("locality") }["longText"],
+                                latitude: place['location']['latitude'],
+                                longitude: place['location']['longitude'],
+                                type: place['primaryType']
+                            }),
+                            data: { turbo_method: :post },
+                            class: "p-1 rounded-lg border-2 border-slate-300" %>
+                            <%= render 'destinations/bookmark_button', place: place %>
+                        <% end %>
+                    </div>
+                </div>
+            </div>
         </div>
-      </li>
-    <% end %>
-  </ul>
+      <% end %>
+
+      <!-- カルーセルのインジケーター -->
+      <div class="absolute bottom-0 left-0 right-0 flex justify-center p-4">
+          <% @response['places'].each_with_index do |_, index| %>
+              <button type="button" class="w-3 h-3 bg-white rounded-full mx-2 focus:outline-none focus:ring" data-carousel-slide-to="<%= index %>"></button>
+          <% end %>
+      </div>
+      <!-- カルーセルのコントロールボタン -->
+      <button type="button" class="absolute top-1/2 bottom-0 left-0 z-30 flex items-center justify-center w-10 h-10 mx-2 bg-white bg-opacity-75 rounded-full focus:outline-none focus:ring hover:bg-opacity-100" data-carousel-prev>
+          <svg class="w-6 h-6 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
+          </svg>
+      </button>
+      <button type="button" class="absolute top-1/2 bottom-0 right-0 z-30 flex items-center justify-center w-10 h-10 mx-2 bg-white bg-opacity-75 rounded-full focus:outline-none focus:ring hover:bg-opacity-100" data-carousel-next>
+          <svg class="w-6 h-6 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+          </svg>
+      </button>
+    </div>
+  </div>
 </div>
 
 <!-- マップの表示領域となる要素を定義。 -->
@@ -136,6 +159,58 @@
       })
     });
   }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    // カルーセルアイテムの取得
+    const items = document.querySelectorAll('[data-carousel-item]');
+    // インジケーターの取得
+    const indicators = document.querySelectorAll('[data-carousel-slide-to]');
+
+    // 現在表示されているアイテムのインデックス
+    let currentIndex = 0;
+
+    function updateIndicators(newIndex) {
+      // 現在アクティブなインジケーターのクラスを削除
+      indicators[currentIndex].classList.remove('active-indicator');
+
+      // 新しいインジケーターにアクティブクラスを追加
+      indicators[newIndex].classList.add('active-indicator');
+    }
+
+    // 指定されたインデックスのアイテムに移動する関数
+    function moveToItem(index) {
+      if (index >= items.length) {
+        index = 0; // 最後のアイテムから次に移動する場合は最初のアイテムに戻る
+      } else if (index < 0) {
+        index = items.length - 1; // 最初のアイテムから前に移動する場合は最後のアイテムに移動
+      }
+      items[currentIndex].classList.add('hidden'); // 現在のアイテムを非表示
+      items[index].classList.remove('hidden'); // 新しいアイテムを表示
+      updateIndicators(index); // インジケーターの更新
+      currentIndex = index; // 現在のインデックスを更新
+    }
+
+    // インジケーターのクリックイベント処理
+    indicators.forEach(button => {
+      button.addEventListener('click', (e) => {
+        const index = parseInt(e.target.getAttribute('data-carousel-slide-to'));
+        moveToItem(index); // クリックされたインジケーターのインデックスに移動
+      });
+    });
+
+    // 前のアイテムに移動するボタンのイベント処理
+    document.querySelector('[data-carousel-prev]').addEventListener('click', () => {
+      moveToItem(currentIndex - 1); // 現在のインデックスから1つ前に移動
+    });
+
+    // 次のアイテムに移動するボタンのイベント処理
+    document.querySelector('[data-carousel-next]').addEventListener('click', () => {
+      moveToItem(currentIndex + 1); // 現在のインデックスから1つ次に移動
+    });
+
+    // 初期状態で最初のアイテムのインジケーターをアクティブにする
+    updateIndicators(0);
+  });
 </script>
 
 <!-- asyncの必要性は、この後の実装していく中で検討する。非同期でマップ作成する方が良いのか。 -->

--- a/app/views/searches/result.html.erb
+++ b/app/views/searches/result.html.erb
@@ -68,19 +68,37 @@
   let markers = []; // マーカーを格納する配列
 
   function initMap() {
-    // ブラウザのセッションストレージから現在地の緯度と経度を取得
+  // ブラウザのセッションストレージから現在地の緯度と経度を取得
     const latitude = parseFloat(sessionStorage.getItem('latitude'));
     const longitude = parseFloat(sessionStorage.getItem('longitude'));
 
     // 取得した現在地の緯度と経度を、マップの中心点の指定時に用いる定数に設定
-    const mapCenter = { lat: latitude, lng: longitude };
+    const currentLocation = { lat: latitude, lng: longitude };
 
     // 'map'をidに持つ要素に表示する地図を作成
     const map = new google.maps.Map(document.getElementById('map'), {
       zoom: 9,
-      center: mapCenter
+      center: currentLocation
     });
 
+    // 現在地を示す青丸のアイコンを作成
+    function setCurrentLocationMaker(map, position){
+      new google.maps.Marker({
+          position: position,
+          map: map,
+          icon: {
+            path: google.maps.SymbolPath.CIRCLE,
+            fillColor: '#115EC3',
+            fillOpacity: 1,
+            strokeColor: 'white',
+            strokeWeight: 2,
+            scale: 7
+          },
+      });
+    }
+
+    // 現在地を示す青丸のアイコンを表示
+    setCurrentLocationMaker(map, currentLocation);
     // 検索結果として表示する各場所に対して繰り返し処理を定義し、マーカーを作成
     // 繰り返し処理の中で各マーカーに紐づく情報ウィンドウも作成し、マーカークリック時に表示されるようイベントハンドラを定義
     places.forEach(function(place) {

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <nav class='flex items-center justify-between bg-cyan-800 h-20'>
+  <nav class='flex items-center justify-between bg-orange-500 h-20'>
     <%= link_to 'トップページ', root_path, class: 'text-slate-50 font-bold inline-block p-5' %>
     <div>
       <%= link_to 'ログイン', login_path, class: 'text-slate-50 font-bold inline-block p-5' %>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,4 +1,4 @@
-<footer id='footer' class='flex items-center bg-cyan-800 text-slate-50 h-16'>
+<footer id='footer' class='flex items-center bg-orange-500 text-slate-50 h-16'>
   <div class='container mx-auto px-4'>
     <div class='flex flex-wrap'>
       <div class='w-full'>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,5 +1,5 @@
 <header>
-  <nav class='flex items-center justify-between bg-cyan-800 h-16 text-sm text-slate-50 font-bold p-3'>
+  <nav class='flex items-center justify-between bg-orange-500 h-16 text-sm text-slate-50 font-bold p-3'>
     <%= link_to 'トップページ', root_path, class: 'inline-block' %>
     <div class='flex space-x-3 items-center'>
       <%= link_to 'ドライブ履歴', drive_records_path %>

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -20,7 +20,7 @@
         </div>
       <% end %>
     <div>
-      <%= f.submit "検索", class: "py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500" %>
+      <%= f.submit "検索", class: "py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white bg-orange-500 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500" %>
     </div>
   </div>
 <% end %>

--- a/app/views/shared/_search_place_form.html.erb
+++ b/app/views/shared/_search_place_form.html.erb
@@ -1,0 +1,86 @@
+<%= form_with model: @user_selection, url: searches_path, data: { turbo: false } do |form| %>
+  <%= render 'shared/error_messages', object: form.object %>
+  <%= form.hidden_field :latitude, id: 'hidden_latitude' %>
+  <%= form.hidden_field :longitude, id: 'hidden_longitude' %>
+
+  <div>
+    <div class="flex flex-row justify-center items-center space-x-4">
+      <!-- ドロップダウンを開くボタン (カテゴリ) の親要素 -->
+      <div class="form-element">
+        <%= button_tag type: 'button', id: 'dropdownSearchButton', class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white rounded-lg bg-orange-400 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500', data: { dropdown_toggle: 'dropdownSearch' } do %>
+          カテゴリ
+          <%= content_tag :svg, class: 'w-2.5 h-2.5 ms-2.5', aria: { hidden: true }, xmlns: 'http://www.w3.org/2000/svg', fill: 'none', viewBox: '0 0 10 6' do %>
+            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
+          <% end %>
+        <% end %>
+        <!-- ドロップダウンのコンテンツ (カテゴリ) -->
+        <div id="dropdownSearch" class="z-10 hidden bg-white rounded-lg shadow w-60 dark:bg-gray-700">
+          <ul class="h-48 px-3 pb-3 overflow-y-auto text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownSearchButton">
+            <div class="form-element space-y-2 flex flex-col justify-center">
+              <%= form.collection_check_boxes :type, GooglePlacesApiType.all, :name, :display_name, include_hidden: false do |b| %>
+                <div class="flex items-center">
+                  <%= b.check_box(class: "w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 dark:focus:ring-blue-600 dark:ring-offset-gray-800 focus:ring-2 dark:bg-gray-700 dark:border-gray-600") %>
+                  <%= b.label(class: "ms-2 text-sm font-medium text-gray-900 dark:text-gray-300") %>
+                </div>
+              <% end %>
+            </div>
+          </ul>
+        </div>
+      </div>
+      <!-- ドロップダウンを開くボタン (気分) -->
+      <div class="form-element">
+        <%= button_tag type: 'button', id: 'dropdownFeelingButton', class: 'inline-flex items-center px-4 py-2 text-sm font-medium text-center text-white rounded-lg bg-orange-400 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500', data: { dropdown_toggle: 'dropdownFeeling' } do %>
+          気分
+          <%= content_tag :svg, class: 'w-2.5 h-2.5 ms-2.5', aria: { hidden: true }, xmlns: 'http://www.w3.org/2000/svg', fill: 'none', viewBox: '0 0 10 6' do %>
+            <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
+          <% end %>
+        <% end %>
+        <!-- ドロップダウンのコンテンツ (気分) -->
+        <div id="dropdownFeeling" class="z-10 hidden bg-white rounded-lg shadow w-60 dark:bg-gray-700">
+          <ul class="px-3 pb-3 overflow-y-auto text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownFeelingButton">
+            <div class="form-element space-y-2">
+              <%= form.collection_radio_buttons :feeling, Feeling.all, :id, :name do |b| %>
+                <div class="flex items-center">
+                  <%= b.radio_button(class: "form-radio hidden") %>
+                  <%= b.label(class: "ms-2 text-sm font-medium text-gray-900 dark:text-gray-300") %>
+                </div>
+              <% end %>
+            </div>
+          </ul>
+        </div>
+      </div>
+    </div>
+
+    <div class="flex flex-row justify-center items-center space-x-4 mt-4">
+      <!-- 運転範囲の選択 -->
+      <div class="form-element">
+        <%= form.select :drive_range, options_for_select(@user_selection.drive_time_options), { include_blank: 'どのくらい走る？' }, class: "form-select block w-60 rounded-md shadow-sm bg-white border-2 border-orange-300 hover:border-orange-500 focus:border-orange-400 focus:ring focus:ring-orange-200 focus:ring-opacity-50 " %>
+      </div>
+  
+      <!-- 検索ボタン -->
+      <div class="form-element">
+        <%= form.submit '検索', class: "bg-orange-500 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500 text-white font-bold py-2 px-4 rounded" %>
+      </div>
+    <div>
+  </div>
+<% end %>
+
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    // カテゴリのドロップダウン制御
+    const dropdownSearchButton = document.getElementById('dropdownSearchButton');
+    const dropdownSearchContent = document.getElementById('dropdownSearch');
+
+    dropdownSearchButton.addEventListener('click', () => {
+      dropdownSearchContent.classList.toggle('hidden');
+    });
+
+    // 気分のドロップダウン制御
+    const dropdownFeelingButton = document.getElementById('dropdownFeelingButton');
+    const dropdownFeelingContent = document.getElementById('dropdownFeeling');
+
+    dropdownFeelingButton.addEventListener('click', () => {
+      dropdownFeelingContent.classList.toggle('hidden');
+    });
+  });
+</script>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -4,23 +4,23 @@
     <%= form_with model: @user do |f| %>
       <%= render 'shared/error_messages', object: @user %>
       <div class="mb-4">
-        <%= f.label :name, class: 'block text-sm font-medium text-gray-700' %>
+        <%= f.label :name, 'ユーザー名', class: 'block text-sm font-medium text-gray-700' %>
         <%= f.text_field :name, class: 'mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm' %>
       </div>
       <div class="mb-4">
-        <%= f.label :email, class: 'block text-sm font-medium text-gray-700' %>
+        <%= f.label :email, 'メールアドレス', class: 'block text-sm font-medium text-gray-700' %>
         <%= f.email_field :email, class: 'mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm' %>
       </div>
       <div class="mb-4">
-        <%= f.label :password, class: 'block text-sm font-medium text-gray-700' %>
+        <%= f.label :password, 'パスワード', class: 'block text-sm font-medium text-gray-700' %>
         <%= f.password_field :password, class: 'mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm' %>
       </div>
       <div class="mb-6">
-        <%= f.label :password_confirmation, class: 'block text-sm font-medium text-gray-700' %>
+        <%= f.label :password_confirmation, 'パスワード確認', class: 'block text-sm font-medium text-gray-700' %>
         <%= f.password_field :password_confirmation, class: 'mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm' %>
       </div>
       <div class="mb-6 flex justify-center">
-        <%= f.submit '登録', class: 'w-2/3 text-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500' %>
+        <%= f.submit '登録', class: 'w-2/3 text-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-orange-400 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500' %>
       </div>
     <% end %>
     <div class='text-center mt-4'>

--- a/app/views/usersessions/new.html.erb
+++ b/app/views/usersessions/new.html.erb
@@ -3,15 +3,15 @@
     <h1 class="text-2xl font-bold text-center mb-4">ログイン</h1>
     <%= form_with url: login_path do |f| %>
       <div class="mb-4">
-        <%= f.label :email, class: 'block text-sm font-medium text-gray-700' %>
+        <%= f.label :email, 'メールアドレス', class: 'block text-sm font-medium text-gray-700' %>
         <%= f.text_field :email, class: 'mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm' %>
       </div>
       <div class="mb-4">
-        <%= f.label :password, class: 'block text-sm font-medium text-gray-700' %>
+        <%= f.label :password, 'パスワード', class: 'block text-sm font-medium text-gray-700' %>
         <%= f.password_field :password, class: 'mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm' %>
       </div>
       <div class="mb-6 flex justify-center">
-        <%= f.submit 'ログイン', class: 'w-2/3 text-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500' %>
+        <%= f.submit 'ログイン', class: 'w-2/3 text-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-orange-400 hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-orange-500' %>
       </div>
     <% end %>
     <div class='text-center mt-4 flex flex-col items-center justify-center space-y-3'>


### PR DESCRIPTION
## 概要
ISSUE: #135 

検索結果表示ページ(searched/result)のUI/UXの調整を行いました。

close #135 

## やったこと

- [x] 検索結果の表示をリスト形式からカルーセル表示に変更
- [x] 表示する検索結果が多すぎるとユーザーの選択の手間が増えるため、結果表示件数を20件から10件に変更
- [x] マップ上にはカルーセルで表示されている場所のマーカーのみ表示されるよう修正
- [x] 検索結果である各場所の詳細情報の表示箇所を、マップ上のマーカーに紐づく情報ウィンドウからカルーセル内部の各アイテムに変更
- [x] 現在地を示すアイコンをマップ上に追加
- [x] 検索フォームを検索結果表示画面にも設置し、容易に再検索できるようにする
