### PR TITLE
検索結果表示画面で目的地を決定した後の一連の処理を実装する

### DIFF
--- a/app/views/destinations/show.html.erb
+++ b/app/views/destinations/show.html.erb
@@ -1,25 +1,25 @@
-<div class="bg-white rounded-lg p-5 m-5 flex flex-col items-center text-slate-700 h-96">
-  <% if @bookmark_destination.website_uri.present?  %>
-    <%= link_to @bookmark_destination.name, @bookmark_destination.website_uri, class: "text-xl font-bold p-3 underline hover:text-slate-400", target: '_blank', rel: 'noopener noreferrer' %>
-  <% else %>
-    <h2 class="text-xl font-bold p-3"><%= @bookmark_destination.name %></h2>
-  <% end %>
-  <p class="text-sm font-semibold"><%= @bookmark_destination.address %></p>
-</div>
+<div class="flex flex-col items-center justify-center">
+  <div class="bg-white rounded-lg p-5 m-5 flex flex-col items-center text-slate-700 h-96 w-96">
+    <% if @bookmark_destination.website_uri.present?  %>
+      <%= link_to @bookmark_destination.name, @bookmark_destination.website_uri, class: "text-lg font-bold p-3 underline hover:text-slate-400", target: '_blank', rel: 'noopener noreferrer' %>
+    <% else %>
+      <h2 class="text-lg font-bold p-3"><%= @bookmark_destination.name %></h2>
+    <% end %>
+    <p class="text-sm font-semibold"><%= @bookmark_destination.address %></p>
+  </div>
 
-<!-- オーバーレイ -->
-<div id="overlay" class="hidden fixed inset-0 bg-slate-900 bg-opacity-50 z-20"></div>
+  <!-- オーバーレイ -->
+  <div id="overlay" class="hidden fixed inset-0 bg-slate-900 bg-opacity-50 z-20"></div>
 
-<div class="flex items-center justify-center">
-  <div class="flex items-center justify-between space-x-14 py-3 relative">
-    <!-- ドロップダウンを開くボタン -->
-    <div>
+  <div class="flex flex-col">
+    <div class="flex justify-between space-x-14 py-3 relative">
+      <!-- ドロップダウンを開くボタン -->
       <%= button_tag type: 'button', id: 'dropdownDepartureButton', class: 'bg-indigo-900 hover:bg-indigo-700 text-white focus:outline-none py-3 px-6 mt-3 w-40 rounded-full', data: { dropdown_toggle: 'dropdownDeparture' } do %>
         ここへ行く
       <% end %>
 
       <!-- ドロップダウンのコンテンツ -->
-      <div id="dropdownDeparture" class="hidden absolute z-30 top-1 left-1/2 transform -translate-x-1/2 w-11/12 rounded-lg shadow-lg bg-slate-50 ring-1 ring-black ring-opacity-5">
+      <div id="dropdownDeparture" class="hidden absolute z-30 top-1 left-1/3 transform -translate-x-1/2 w-11/12 rounded-lg shadow-lg bg-slate-50 ring-1 ring-black ring-opacity-5">
         <div class="flex flex-col justify-center h-full">
           <div class="flex flex-row items-center justify-center space-x-3 mt-5">
             <%= link_to "Yahoo!カーナビで行く", "yjcarnavi://navi/select?lat=#{@bookmark_destination.latitude}&lon=#{@bookmark_destination.longitude}", class: "text-sm text-gray-700 border-2 border-blue-500 hover:border-blue-700 hover:bg-blue-200 rounded-full px-3 py-2 transition-colors duration-200 ease-in-out" %>
@@ -30,11 +30,15 @@
           </div>
         </div>
       </div>
-    </div>
 
-    <%= link_to '一覧へ戻る', bookmarks_destinations_path, class: "hover:bg-slate-50 text-slate-600 text-center border border-slate-600 py-3 px-6 mt-3 w-40 rounded-full" %>
+      <%= link_to '一覧へ戻る', bookmarks_destinations_path, class: "hover:bg-slate-50 text-slate-600 text-center border border-slate-600 py-3 px-6 mt-3 w-40 rounded-full" %>
+    </div>
+    <div class="text-xs text-left">
+      ※ 応答がない場合、お手数ですが<br>&emsp;画面をリロードした上で<br>&emsp;再度お試しください。
+    </div>
   </div>
 </div>
+
 
 <script>
   // 「もう一度行く」ボタンをクリックした際のドロップダウン表示処理

--- a/app/views/destinations/show.html.erb
+++ b/app/views/destinations/show.html.erb
@@ -6,9 +6,62 @@
   <% end %>
   <p class="text-sm font-semibold"><%= @bookmark_destination.address %></p>
 </div>
-<div class="flex items-center justify-center mt-8">
-  <div class="flex justify-between space-x-8 pb-3 px-3">
-    <%= link_to 'ここに行く', '#', class: "bg-indigo-900 hover:bg-indigo-700 focus:outline-none focus:ring-indigo-500 text-white text-center py-3 px-6 w-40 rounded-full" %>
-    <%= link_to '一覧へ戻る', bookmarks_destinations_path, class: "hover:bg-slate-300 text-slate-600 text-center border border-slate-600 py-3 px-6 w-40 rounded-full" %>
+
+<!-- オーバーレイ -->
+<div id="overlay" class="hidden fixed inset-0 bg-slate-900 bg-opacity-50 z-20"></div>
+
+<div class="flex items-center justify-center">
+  <div class="flex items-center justify-between space-x-14 py-3 relative">
+    <!-- ドロップダウンを開くボタン -->
+    <div>
+      <%= button_tag type: 'button', id: 'dropdownDepartureButton', class: 'bg-indigo-900 hover:bg-indigo-700 text-white focus:outline-none py-3 px-6 mt-3 w-40 rounded-full', data: { dropdown_toggle: 'dropdownDeparture' } do %>
+        ここへ行く
+      <% end %>
+
+      <!-- ドロップダウンのコンテンツ -->
+      <div id="dropdownDeparture" class="hidden absolute z-30 top-1 left-1/2 transform -translate-x-1/2 w-11/12 rounded-lg shadow-lg bg-slate-50 ring-1 ring-black ring-opacity-5">
+        <div class="flex flex-col justify-center h-full">
+          <div class="flex flex-row items-center justify-center space-x-3 mt-5">
+            <%= link_to "Yahoo!カーナビで行く", "yjcarnavi://navi/select?lat=#{@bookmark_destination.latitude}&lon=#{@bookmark_destination.longitude}", class: "text-sm text-gray-700 border-2 border-blue-500 hover:border-blue-700 hover:bg-blue-200 rounded-full px-3 py-2 transition-colors duration-200 ease-in-out" %>
+            <%= link_to "Google Mapで行く", "https://www.google.com/maps/dir/?api=1&destination=#{@bookmark_destination.latitude},#{@bookmark_destination.longitude}&travelmode=driving", class: "text-sm text-gray-700 border-2 border-red-500 hover:border-red-700 hover:bg-red-200 rounded-full px-3 py-2 transition-colors duration-200 ease-in-out" %>
+          </div>
+          <div class="text-xs ml-4 mt-2 pb-1">
+          ※ Yahoo!カーナビアプリ の<br>&emsp;インストールが必要です
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <%= link_to '一覧へ戻る', bookmarks_destinations_path, class: "hover:bg-slate-50 text-slate-600 text-center border border-slate-600 py-3 px-6 mt-3 w-40 rounded-full" %>
   </div>
 </div>
+
+<script>
+  // 「もう一度行く」ボタンをクリックした際のドロップダウン表示処理
+  document.addEventListener('DOMContentLoaded', () => {
+    const dropdownDepartureButton = document.getElementById('dropdownDepartureButton');
+    const dropdownDepartureContent = document.getElementById('dropdownDeparture');
+    const overlay = document.getElementById('overlay');
+
+    // 「ここへ行く」ボタンをクリックした際にドロップダウンを表示するイベント
+    dropdownDepartureButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      dropdownDepartureContent.classList.toggle('hidden');
+      overlay.classList.toggle('hidden'); // オーバーレイの表示を切り替える
+    });
+
+    // オーバーレイをクリックしたときにドロップダウンを閉じる
+    overlay.addEventListener('click', () => {
+        dropdownDepartureContent.classList.add('hidden');
+        overlay.classList.add('hidden');
+    });
+
+    // ドロップダウン要素以外の場所がクリックされたらドロップダウンを閉じる
+    document.addEventListener('click', (event) => {
+      if (!dropdownDepartureButton.contains(event.target) && !dropdownDepartureContent.contains(event.target)) {
+          dropdownDepartureContent.classList.add('hidden');
+          overlay.classList.add('hidden');
+      }
+    });
+  });
+</script>

--- a/app/views/drive_records/show.html.erb
+++ b/app/views/drive_records/show.html.erb
@@ -10,9 +10,62 @@
   <p class="text-sm font-semibold"><%= @drive_record_destination.address %></p>
   <p class="py-5">日付: <%= @drive_record_destination.created_at %></p>
 </div>
-<div class="flex items-center justify-center mt-8">
-  <div class="flex justify-between space-x-8 pb-3 px-3">
-    <%= link_to ' もう一度行く', '#', class: "bg-indigo-900 hover:bg-indigo-700 focus:outline-none focus:ring-indigo-500 text-white text-center py-3 px-6 w-40 rounded-full" %>
-    <%= link_to '一覧へ戻る', drive_records_path, class: "hover:bg-slate-300 text-slate-600 text-center border border-slate-600 py-3 px-6 w-40 rounded-full" %>
+
+<!-- オーバーレイ -->
+<div id="overlay" class="hidden fixed inset-0 bg-slate-900 bg-opacity-50 z-20"></div>
+
+<div class="flex items-center justify-center">
+  <div class="flex items-center justify-between space-x-14 py-3 relative">
+    <!-- ドロップダウンを開くボタン -->
+    <div>
+      <%= button_tag type: 'button', id: 'dropdownDepartureButton', class: 'bg-indigo-900 hover:bg-indigo-700 text-white focus:outline-none py-3 px-6 mt-3 w-40 rounded-full', data: { dropdown_toggle: 'dropdownDeparture' } do %>
+        もう一度行く
+      <% end %>
+
+      <!-- ドロップダウンのコンテンツ -->
+      <div id="dropdownDeparture" class="hidden absolute z-30 top-1 left-1/2 transform -translate-x-1/2 w-11/12 rounded-lg shadow-lg bg-slate-50 ring-1 ring-black ring-opacity-5">
+        <div class="flex flex-col justify-center h-full">
+          <div class="flex flex-row items-center justify-center space-x-3 mt-5">
+            <%= link_to "Yahoo!カーナビで行く", "yjcarnavi://navi/select?lat=#{@drive_record_destination.latitude}&lon=#{@drive_record_destination.longitude}", class: "text-sm text-gray-700 border-2 border-blue-500 hover:border-blue-700 hover:bg-blue-200 rounded-full px-3 py-2 transition-colors duration-200 ease-in-out" %>
+            <%= link_to "Google Mapで行く", "https://www.google.com/maps/dir/?api=1&destination=#{@drive_record_destination.latitude},#{@drive_record_destination.longitude}&travelmode=driving", class: "text-sm text-gray-700 border-2 border-red-500 hover:border-red-700 hover:bg-red-200 rounded-full px-3 py-2 transition-colors duration-200 ease-in-out" %>
+          </div>
+          <div class="text-xs ml-4 mt-2 pb-1">
+          ※ Yahoo!カーナビアプリ の<br>&emsp;インストールが必要です
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <%= link_to '一覧へ戻る', drive_records_path, class: "hover:bg-slate-50 text-slate-600 text-center border border-slate-600 py-3 px-6 mt-3 w-40 rounded-full" %>
   </div>
 </div>
+
+<script>
+  // 「もう一度行く」ボタンをクリックした際のドロップダウン表示処理
+  document.addEventListener('DOMContentLoaded', () => {
+    const dropdownDepartureButton = document.getElementById('dropdownDepartureButton');
+    const dropdownDepartureContent = document.getElementById('dropdownDeparture');
+    const overlay = document.getElementById('overlay');
+
+    // 「ここへ行く」ボタンをクリックした際にドロップダウンを表示するイベント
+    dropdownDepartureButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      dropdownDepartureContent.classList.toggle('hidden');
+      overlay.classList.toggle('hidden'); // オーバーレイの表示を切り替える
+    });
+
+    // オーバーレイをクリックしたときにドロップダウンを閉じる
+    overlay.addEventListener('click', () => {
+        dropdownDepartureContent.classList.add('hidden');
+        overlay.classList.add('hidden');
+    });
+
+    // ドロップダウン要素以外の場所がクリックされたらドロップダウンを閉じる
+    document.addEventListener('click', (event) => {
+      if (!dropdownDepartureButton.contains(event.target) && !dropdownDepartureContent.contains(event.target)) {
+          dropdownDepartureContent.classList.add('hidden');
+          overlay.classList.add('hidden');
+      }
+    });
+  });
+</script>

--- a/app/views/drive_records/show.html.erb
+++ b/app/views/drive_records/show.html.erb
@@ -1,29 +1,29 @@
-<div>
-  <h1 class="text-center font-bold text-slate-600 text-3xl mb-8">ドライブ履歴詳細</h1>
-</div>
-<div class="bg-white rounded-lg p-5 m-5 flex flex-col items-center text-slate-700 h-96">
-  <% if @drive_record_destination.website_uri.present? %>
-    <%= link_to @drive_record_destination.name, @drive_record_destination.website_uri, class: "text-xl font-bold p-3 underline hover:text-slate-400", target: '_blank', rel: 'noopener noreferrer' %>
-  <% else %>
-    <h2 class="text-xl font-bold p-3"><%= @drive_record_destination.name %></h2>
-  <% end %>
-  <p class="text-sm font-semibold"><%= @drive_record_destination.address %></p>
-  <p class="py-5">日付: <%= @drive_record_destination.created_at %></p>
-</div>
+<div class="flex flex-col items-center justify-center">
+  <div>
+    <h1 class="text-center font-bold text-slate-600 text-3xl mb-8">ドライブ履歴詳細</h1>
+  </div>
+  <div class="bg-white rounded-lg p-5 m-5 flex flex-col items-center text-slate-700 h-96 w-96">
+    <% if @drive_record_destination.website_uri.present? %>
+      <%= link_to @drive_record_destination.name, @drive_record_destination.website_uri, class: "text-lg font-bold p-3 underline hover:text-slate-400", target: '_blank', rel: 'noopener noreferrer' %>
+    <% else %>
+      <h2 class="text-lg font-bold p-3"><%= @drive_record_destination.name %></h2>
+    <% end %>
+    <p class="text-sm font-semibold"><%= @drive_record_destination.address %></p>
+    <p class="py-5">日付: <%= @drive_record_destination.created_at %></p>
+  </div>
 
-<!-- オーバーレイ -->
-<div id="overlay" class="hidden fixed inset-0 bg-slate-900 bg-opacity-50 z-20"></div>
+  <!-- オーバーレイ -->
+  <div id="overlay" class="hidden fixed inset-0 bg-slate-900 bg-opacity-50 z-20"></div>
 
-<div class="flex items-center justify-center">
-  <div class="flex items-center justify-between space-x-14 py-3 relative">
-    <!-- ドロップダウンを開くボタン -->
-    <div>
+  <div class="flex flex-col">
+    <div class="flex justify-between space-x-14 py-3 relative">
+      <!-- ドロップダウンを開くボタン -->
       <%= button_tag type: 'button', id: 'dropdownDepartureButton', class: 'bg-indigo-900 hover:bg-indigo-700 text-white focus:outline-none py-3 px-6 mt-3 w-40 rounded-full', data: { dropdown_toggle: 'dropdownDeparture' } do %>
         もう一度行く
       <% end %>
 
       <!-- ドロップダウンのコンテンツ -->
-      <div id="dropdownDeparture" class="hidden absolute z-30 top-1 left-1/2 transform -translate-x-1/2 w-11/12 rounded-lg shadow-lg bg-slate-50 ring-1 ring-black ring-opacity-5">
+      <div id="dropdownDeparture" class="hidden absolute z-30 top-1 left-1/3 transform -translate-x-1/2 w-11/12 rounded-lg shadow-lg bg-slate-50 ring-1 ring-black ring-opacity-5">
         <div class="flex flex-col justify-center h-full">
           <div class="flex flex-row items-center justify-center space-x-3 mt-5">
             <%= link_to "Yahoo!カーナビで行く", "yjcarnavi://navi/select?lat=#{@drive_record_destination.latitude}&lon=#{@drive_record_destination.longitude}", class: "text-sm text-gray-700 border-2 border-blue-500 hover:border-blue-700 hover:bg-blue-200 rounded-full px-3 py-2 transition-colors duration-200 ease-in-out" %>
@@ -33,10 +33,12 @@
           ※ Yahoo!カーナビアプリ の<br>&emsp;インストールが必要です
           </div>
         </div>
-      </div>
-    </div>
 
-    <%= link_to '一覧へ戻る', drive_records_path, class: "hover:bg-slate-50 text-slate-600 text-center border border-slate-600 py-3 px-6 mt-3 w-40 rounded-full" %>
+      <%= link_to '一覧へ戻る', drive_records_path, class: "hover:bg-slate-50 text-slate-600 text-center border border-slate-600 py-3 px-6 mt-3 w-40 rounded-full" %>
+    </div>
+    <div class="text-xs text-left">
+      ※ 応答がない場合、お手数ですが<br>&emsp;画面をリロードした上で<br>&emsp;再度お試しください。
+    </div>
   </div>
 </div>
 

--- a/app/views/searches/new.html.erb
+++ b/app/views/searches/new.html.erb
@@ -12,15 +12,15 @@
       <div class="flex flex-row justify-center items-center space-x-6">
         <!-- ドロップダウンを開くボタン (カテゴリ) の親要素 -->
         <div class="form-element relative">
-          <%= button_tag type: 'button', id: 'dropdownSearchButton', class: 'inline-flex items-center px-4 py-2 text-md font-medium text-center text-slate-600 rounded-lg shadow-sm bg-white border-2 border-indigo-300 hover:border-indigo-500 focus:border-indigo-400 focus:ring focus:ring-indigo-200 focus:ring-opacity-50', data: { dropdown_toggle: 'dropdownSearch' } do %>
+          <%= button_tag type: 'button', id: 'dropdownTypeButton', class: 'inline-flex items-center px-4 py-2 text-md font-medium text-center text-slate-600 rounded-lg shadow-sm bg-white border-2 border-indigo-300 hover:border-indigo-500 focus:border-indigo-400 focus:ring focus:ring-indigo-200 focus:ring-opacity-50', data: { dropdown_toggle: 'dropdownType' } do %>
             除外カテゴリ(任意)
             <%= content_tag :svg, class: 'w-2.5 h-2.5 ms-2.5', aria: { hidden: true }, xmlns: 'http://www.w3.org/2000/svg', fill: 'none', viewBox: '0 0 10 6' do %>
               <path stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="m1 1 4 4 4-4"/>
             <% end %>
           <% end %>
           <!-- ドロップダウンのコンテンツ (カテゴリ) -->
-          <div id="dropdownSearch" class="absolute z-10 top-16 left-10 hidden bg-white rounded-lg shadow w-60 dark:bg-gray-700">
-            <ul class="h-48 px-3 pb-3 overflow-y-auto text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownSearchButton">
+          <div id="dropdownType" class="absolute z-10 top-16 left-10 hidden bg-white rounded-lg shadow w-60 dark:bg-gray-700">
+            <ul class="h-48 px-3 pb-3 overflow-y-auto text-sm text-gray-700 dark:text-gray-200" aria-labelledby="dropdownTypeButton">
               <div class="form-element space-y-2 flex flex-col justify-center">
                 <%= form.collection_check_boxes :type, GooglePlacesApiType.limit(15), :name, :display_name, include_hidden: false do |b| %>
                   <div class="flex items-center">
@@ -110,14 +110,14 @@
   }
 
   document.addEventListener('DOMContentLoaded', () => {
-    const dropdownSearchButton = document.getElementById('dropdownSearchButton');
-    const dropdownSearchContent = document.getElementById('dropdownSearch');
+    const dropdownTypeButton = document.getElementById('dropdownTypeButton');
+    const dropdownTypeContent = document.getElementById('dropdownType');
     const dropdownFeelingButton = document.getElementById('dropdownFeelingButton');
     const dropdownFeelingContent = document.getElementById('dropdownFeeling');
   
     // カテゴリのドロップダウン制御
-    dropdownSearchButton.addEventListener('click', (event) => {
-      dropdownSearchContent.classList.toggle('hidden');
+    dropdownTypeButton.addEventListener('click', (event) => {
+      dropdownTypeContent.classList.toggle('hidden');
       event.stopPropagation(); // ドキュメントのイベント伝播を停止
     });
 
@@ -129,8 +129,8 @@
 
     // ドロップダウン要素以外の場所がクリックされたらドロップダウンを閉じる
     document.addEventListener('click', (event) => {
-      if (!dropdownSearchButton.contains(event.target) && !dropdownSearchContent.contains(event.target)) {
-        dropdownSearchContent.classList.add('hidden');
+      if (!dropdownTypeButton.contains(event.target) && !dropdownTypeContent.contains(event.target)) {
+        dropdownTypeContent.classList.add('hidden');
       }
       if (!dropdownFeelingButton.contains(event.target) && !dropdownFeelingContent.contains(event.target)) {
         dropdownFeelingContent.classList.add('hidden');

--- a/app/views/searches/result.html.erb
+++ b/app/views/searches/result.html.erb
@@ -1,16 +1,16 @@
 <!-- マップの表示領域となる要素を定義。 -->
-<div class="flex justify-center items-center">
+<div class="flex justify-center">
   <div id="map" class="h-64 w-11/12 md:w-96 rounded-lg"></div>
 </div>
 
 <div>
-  <div id="default-carousel" class="relative h-full w-full py-5 flex justify-center" data-carousel="slide">
+  <div id="default-carousel" class="relative h-full py-5 flex justify-center" data-carousel="slide">
     <!-- カルーセルのラッパー -->
     <div class="relative h-96 w-full md:w-96 overflow-hidden rounded-lg">
       <% @response['places'].each_with_index do |place, index| %>
         <!-- カルーセル内の個々のアイテム -->
-        <div class="<%= 'hidden' unless index.zero? %> duration-700 ease-in-out h-full" data-carousel-item>
-          <div class="bg-white rounded-lg py-5 mx-5 h-full flex flex-col items-center text-slate-700">
+        <div class="<%= 'hidden' unless index.zero? %> h-full" data-carousel-item  data-latitude="<%= place['location']['latitude'] %>" data-longitude="<%= place['location']['longitude']%>" >
+          <div class="bg-white rounded-lg py-4 mx-5 h-full flex flex-col items-center text-slate-700">
             <%= image_tag @photos[index]['photoUri'], class: "my-2 px-5" %>
             <div class="h-full w-4/5 my-2 px-5">
               <div class="flex flex-row space-x-3 justify-center items-center w-full mb-2">
@@ -20,8 +20,6 @@
                 <% end %>
               </div>
               <div class="flex flex-col space-y-2 items-center w-full">
-                <%= link_to 'ルート検索 (Yahoo!カーナビ)', "yjcarnavi://navi/select?lat=#{place['location']['latitude']}&lon=#{place['location']['longitude']}" %>
-                <%= link_to 'ルート検索 (Google Map)', '#', class: 'google-map-link', data: { lat: place['location']['latitude'], lng: place['location']['longitude'] } %>
                 <% if logged_in? %>
                   <%= link_to 'ここへ行く', drive_records_path(destination: {
                       name: place['displayName']['text'],
@@ -50,12 +48,12 @@
       </div>
 
       <!-- カルーセルのコントロールボタン -->
-      <button type="button" class="absolute top-1/2 bottom-0 left-0 z-30 flex items-center justify-center w-10 h-10 mx-2 bg-white bg-opacity-75 rounded-full focus:outline-none focus:ring hover:bg-opacity-100" data-carousel-prev>
+      <button type="button" class="absolute top-1/2 bottom-0 left-0 z-10 flex items-center justify-center w-10 h-10 mx-2 bg-white bg-opacity-75 rounded-full focus:outline-none focus:ring hover:bg-opacity-100" data-carousel-prev>
           <svg class="w-6 h-6 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"></path>
           </svg>
       </button>
-      <button type="button" class="absolute top-1/2 bottom-0 right-0 z-30 flex items-center justify-center w-10 h-10 mx-2 bg-white bg-opacity-75 rounded-full focus:outline-none focus:ring hover:bg-opacity-100" data-carousel-next>
+      <button type="button" class="absolute top-1/2 bottom-0 right-0 z-10 flex items-center justify-center w-10 h-10 mx-2 bg-white bg-opacity-75 rounded-full focus:outline-none focus:ring hover:bg-opacity-100" data-carousel-next>
           <svg class="w-6 h-6 text-gray-700" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
           </svg>
@@ -64,27 +62,37 @@
   </div>
 </div>
 
+<!-- オーバーレイ -->
+<div id="overlay" class="hidden fixed inset-0 bg-slate-900 bg-opacity-50 z-20"></div>
+
 <div class="flex items-center justify-center">
-  <div class="flex justify-between space-x-8 pb-3 px-3">
-    <%= link_to 'ここに行く', '#', class: "bg-indigo-900 hover:bg-indigo-700 focus:outline-none focus:ring-indigo-500 text-white text-center py-3 px-6 w-40 rounded-full" %>
-    <%= link_to '再検索', '#', class: "hover:bg-slate-300 text-slate-600 text-center border border-slate-600 py-3 px-6 w-40 rounded-full" %>
+  <div class="flex items-center justify-between space-x-14 py-3 relative">
+    <!-- ドロップダウンを開くボタン -->
+    <div>
+      <%= button_tag type: 'button', id: 'dropdownDepartureButton', class: 'bg-indigo-900 hover:bg-indigo-700 text-white focus:outline-none py-3 px-6 mt-3 w-40 rounded-full', data: { dropdown_toggle: 'dropdownDeparture' } do %>
+        ここへ行く
+      <% end %>
+
+      <!-- ドロップダウンのコンテンツ -->
+      <div id="dropdownDeparture" class="hidden absolute z-30 top-1 left-1/2 transform -translate-x-1/2 w-11/12 rounded-lg shadow-lg bg-slate-50 ring-1 ring-black ring-opacity-5">
+        <div class="flex flex-col justify-center h-full">
+          <div class="flex flex-row items-center justify-center space-x-3 mt-5">
+            <%= link_to "Yahoo!カーナビで行く", "#", class: "yahoo-navi-link text-sm text-gray-700 border-2 border-blue-500 hover:border-blue-700 hover:bg-blue-200 rounded-full px-3 py-2 transition-colors duration-200 ease-in-out" %>
+            <%= link_to "Google Mapで行く", "#", class: "google-map-link text-sm text-gray-700 border-2 border-red-500 hover:border-red-700 hover:bg-red-200 rounded-full px-3 py-2 transition-colors duration-200 ease-in-out" %>
+          </div>
+          <div class="text-xs ml-4 mt-2 pb-1">
+          ※ Yahoo!カーナビアプリ の<br>&emsp;インストールが必要です
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <%= link_to '再検索', '#', class: "hover:bg-slate-50 text-slate-600 text-center border border-slate-600 py-3 px-6 mt-3 w-40 rounded-full" %>
   </div>
 </div>
 
 <script>
-  // ページのDOM要素が全て読み込まれたら、ブラウザのセッションストレージに格納されている緯度と経度のデータを取得し、上記フォーム内の該当するhidden_fieldに設定する処理
-  // 現在地の緯度と経度のデータは、ユーザーがフォームで選択した内容とまとめてコントローラに送って処理したいため、hidden_fieldに設定する
-  document.addEventListener('DOMContentLoaded', (event) => {
-  const latitude = sessionStorage.getItem('latitude');
-  const longitude = sessionStorage.getItem('longitude');
-
-  document.getElementById('hidden_latitude').value = latitude;
-  document.getElementById('hidden_longitude').value = longitude;
-  });
-
-
-  // Searches#resultから受け取った各場所のデータ(@response['places'])を変数に格納
-  const places = <%= @response['places'].to_json.html_safe %>;
+  const places = <%= @response['places'].to_json.html_safe %>; // Searches#resultから受け取った各場所のデータ(@response['places'])を変数に格納
   let markers = []; // マーカーを格納する配列
 
   function initMap() {
@@ -148,20 +156,20 @@
     });
   }
 
+  // カルーセルアイテムの表示切り替え処理
   document.addEventListener('DOMContentLoaded', () => {
-    // カルーセルアイテムの取得
-    const items = document.querySelectorAll('[data-carousel-item]');
-    // インジケーターの取得
-    const indicators = document.querySelectorAll('[data-carousel-slide-to]');
+    const items = document.querySelectorAll('[data-carousel-item]'); // カルーセルアイテムの取得
+    const indicators = document.querySelectorAll('[data-carousel-slide-to]'); // インジケーターの取得
+    // カルーセル外部の「ここへ行く」ボタンクリックで表示される、ドロップダウンアイテム内のリンク要素(表示されているカルーセルアイテムに対応する場所に応じてパラメータを変えるもの)を取得
+    const yahooNaviLink = document.querySelector('#dropdownDeparture a.yahoo-navi-link');
+    const googleMapLink = document.querySelector('#dropdownDeparture a.google-map-link');
 
-    // 現在表示されているアイテムのインデックス
-    let currentIndex = 0;
+    let currentIndex = 0; // 現在表示されているアイテムのインデックス
 
+    // カルーセルアイテムの表示切り替えに連動してインジケーターのスタイルを切り替える処理
     function updateIndicators(newIndex) {
-      // 現在アクティブなインジケーターのクラスを削除
-      indicators[currentIndex].classList.remove('active-indicator');
-      // 新しいインジケーターにアクティブクラスを追加
-      indicators[newIndex].classList.add('active-indicator');
+      indicators[currentIndex].classList.remove('active-indicator'); // 現在アクティブなインジケーターのアクティブクラスを削除
+      indicators[newIndex].classList.add('active-indicator'); // 新しいインジケーターにアクティブクラスを追加
     }
 
     // 指定されたインデックスのアイテムに移動する関数
@@ -173,6 +181,16 @@
       }
       items[currentIndex].classList.add('hidden'); // 現在のアイテムを非表示
       items[index].classList.remove('hidden'); // 新しいアイテムを表示
+
+      // 新しいアイテムの緯度経度を取得
+      const newItem = items[index];
+      const latitude = newItem.getAttribute('data-latitude');
+      const longitude = newItem.getAttribute('data-longitude');
+
+      // カルーセル外部の「ここへ行く」ボタンクリックで表示される、ドロップダウンアイテム内のリンクを更新
+      yahooNaviLink.href = `yjcarnavi://navi/select?lat=${latitude}&lon=${longitude}`;
+      googleMapLink.href = `https://www.google.com/maps/dir/?api=1&destination=${latitude},${longitude}&travelmode=driving`;
+
       updateIndicators(index); // インジケーターの更新
       updateMarkers(index); // マーカーの表示を更新
       currentIndex = index; // 現在のインデックスを更新
@@ -200,31 +218,31 @@
     updateIndicators(0);
   });
 
-  // ページが読み込まれた後に実行されるイベントリスナー
+  // 「ここへ行く」ボタンをクリックした際のドロップダウン表示処理
   document.addEventListener('DOMContentLoaded', () => {
-    // クラス名 'google-map-link' を持つすべてのリンクを取得
-    const googleMapLinks = document.querySelectorAll('.google-map-link')
-    // 各リンクにイベントリスナーを設定
-    googleMapLinks.forEach(link => {
-      link.addEventListener('click', (event) => {
-        // デフォルトのアクション（リンクの遷移）を防止
-        event.preventDefault()
-        // クリックされたリンクから目的地の緯度と経度を取得
-        const destinationLat = event.currentTarget.getAttribute('data-lat');
-        const destinationLng = event.currentTarget.getAttribute('data-lng')
-        // ユーザーの現在地を取得
-        navigator.geolocation.getCurrentPosition((position) => {
-          // 現在地の緯度と経度を取得
-          const originLat = position.coords.latitude;
-          const originLng = position.coords.longitude
-          // Googleマップのルート探索URLを生成し、新しいタブで開く
-          const googleMapsUri = `https://www.google.com/maps/dir/?api=1&origin=${originLat},${originLng}&destination=${destinationLat},${destinationLng}`;
-          window.open(googleMapsUri, '_blank', 'noopener,noreferrer');
-        }, (error) => {
-          // 現在地の取得に失敗した場合のエラーハンドリング
-          alert('現在地を取得できませんでした。');
-        });
-      });
+    const dropdownDepartureButton = document.getElementById('dropdownDepartureButton');
+    const dropdownDepartureContent = document.getElementById('dropdownDeparture');
+    const overlay = document.getElementById('overlay');
+
+    // 「ここへ行く」ボタンをクリックした際にドロップダウンを表示するイベント
+    dropdownDepartureButton.addEventListener('click', (event) => {
+      event.preventDefault();
+      dropdownDepartureContent.classList.toggle('hidden');
+      overlay.classList.toggle('hidden'); // オーバーレイの表示を切り替える
+    });
+
+    // オーバーレイをクリックしたときにドロップダウンを閉じる
+    overlay.addEventListener('click', () => {
+        dropdownDepartureContent.classList.add('hidden');
+        overlay.classList.add('hidden');
+    });
+
+    // ドロップダウン要素以外の場所がクリックされたらドロップダウンを閉じる
+    document.addEventListener('click', (event) => {
+      if (!dropdownDepartureButton.contains(event.target) && !dropdownDepartureContent.contains(event.target)) {
+          dropdownDepartureContent.classList.add('hidden');
+          overlay.classList.add('hidden');
+      }
     });
   });
 </script>

--- a/app/views/searches/result.html.erb
+++ b/app/views/searches/result.html.erb
@@ -19,22 +19,6 @@
                   <%= render 'destinations/bookmark_button', place: place %>
                 <% end %>
               </div>
-              <div class="flex flex-col space-y-2 items-center w-full">
-                <% if logged_in? %>
-                  <%= link_to 'ここへ行く', drive_records_path(destination: {
-                      name: place['displayName']['text'],
-                      address: place['formattedAddress'],
-                      top_level_area: place["addressComponents"].find { |component| component["types"].include?("administrative_area_level_1") }["longText"],
-                      second_level_area: place["addressComponents"].find { |component| component["types"].include?("administrative_area_level_2") || component["types"].include?("locality") }["longText"],
-                      latitude: place['location']['latitude'],
-                      longitude: place['location']['longitude'],
-                      website_uri: place['websiteUri'],
-                      type: place['primaryType']
-                  }),
-                  data: { turbo_method: :post }
-                  %>
-                <% end %>
-              </div>
             </div>
           </div>
         </div>

--- a/app/views/searches/result.html.erb
+++ b/app/views/searches/result.html.erb
@@ -87,7 +87,7 @@
       </div>
     </div>
 
-    <%= link_to '再検索', '#', class: "hover:bg-slate-50 text-slate-600 text-center border border-slate-600 py-3 px-6 mt-3 w-40 rounded-full" %>
+    <%= link_to '再検索', root_path, class: "hover:bg-slate-50 text-slate-600 text-center border border-slate-600 py-3 px-6 mt-3 w-40 rounded-full" %>
   </div>
 </div>
 

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -1,12 +1,16 @@
 <header>
   <nav class='flex items-center justify-between h-16 text-sm text-slate-600 font-bold p-3 relative'>
+    <%= link_to root_path, class: 'inline-block' do %>
+      <%= image_tag 'logo_without_appname.png', size: "50x50", class: 'rounded-full' %>
+    <% end %>
+
     <!-- ハンバーガーアイコン -->
     <div id="hamburger" class="cursor-pointer">
       <i class="fas fa-bars fa-2x"></i>
     </div>
 
     <!-- ドロップダウンメニュー -->
-    <div id="menu" class="hidden absolute bg-white shadow-md rounded-md mt-2 py-2 w-64 top-12 z-10">
+    <div id="menu" class="hidden absolute bg-white shadow-md rounded-md mt-2 py-2 w-64 top-12 right-3 z-10">
       <ul class="flex flex-col">
         <li><%= link_to 'ログイン', login_path, class: 'block px-4 py-2 hover:bg-gray-100' %></li>
         <li><%= link_to '新規登録', new_user_path, class: 'block px-4 py-2 hover:bg-gray-100' %></li>
@@ -17,10 +21,6 @@
         <li class='block px-4 pt-4 pb-2 hover:bg-gray-100 text-xs font-semibold'>Copyright © ...次、どこ行く？</li>
       </ul>
     </div>
-
-    <%= link_to root_path, class: 'inline-block' do %>
-      <%= image_tag 'logo_without_appname.png', size: "50x50", class: 'rounded-full' %>
-    <% end %>
   </nav>
 </header>
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,12 +1,16 @@
 <header>
   <nav class='flex items-center justify-between h-16 text-sm text-slate-600 font-bold p-3 relative'>
+    <%= link_to root_path, class: 'inline-block' do %>
+      <%= image_tag 'logo_without_appname.png', size: "50x50", class: 'rounded-full' %>
+    <% end %>
+
     <!-- ハンバーガーアイコン -->
     <div id="hamburger" class="cursor-pointer">
       <i class="fas fa-bars fa-2x"></i>
     </div>
 
     <!-- ドロップダウンメニュー -->
-    <div id="menu" class="hidden absolute bg-white shadow-md rounded-md mt-2 py-2 w-64 top-12 z-10">
+    <div id="menu" class="hidden absolute bg-white shadow-md rounded-md mt-2 py-2 w-64 top-12 right-3 z-10">
       <ul class="flex flex-col">
         <li><%= link_to 'ドライブ履歴', drive_records_path, class: 'block px-4 py-2 hover:bg-gray-100' %></li>
         <li><%= link_to 'ブックマーク', bookmarks_destinations_path, class: 'block px-4 py-2 hover:bg-gray-100' %></li>
@@ -19,10 +23,6 @@
         <li class='block px-4 pt-4 pb-2 hover:bg-gray-100 text-xs font-semibold'>Copyright © ...次、どこ行く？</li>
       </ul>
     </div>
-
-    <%= link_to root_path, class: 'inline-block' do %>
-      <%= image_tag 'logo_without_appname.png', size: "50x50", class: 'rounded-full' %>
-    <% end %>
   </nav>
 </header>
 

--- a/db/migrate/20240119091124_change_latitude_and_longitude_in_destinations.rb
+++ b/db/migrate/20240119091124_change_latitude_and_longitude_in_destinations.rb
@@ -1,0 +1,6 @@
+class ChangeLatitudeAndLongitudeInDestinations < ActiveRecord::Migration[7.1]
+  def up
+    change_column :destinations, :latitude, :decimal, precision: 8, scale: 6
+    change_column :destinations, :longitude, :decimal, precision: 9, scale: 6
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_17_174452) do
+ActiveRecord::Schema[7.1].define(version: 2024_01_19_091124) do
   create_table "authentications", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "provider", null: false
@@ -33,8 +33,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_17_174452) do
   create_table "destinations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "address"
-    t.float "latitude"
-    t.float "longitude"
+    t.decimal "latitude", precision: 8, scale: 6
+    t.decimal "longitude", precision: 9, scale: 6
     t.bigint "google_places_api_type_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
## 概要
ISSUE: #161 

ユーザーが目的地を決定した後、経路案内を開始できるまでの一連の処理を実装しました。

close #161 

## やったこと

- [x] 検索結果表示画面(`searches/result`)の「ここへ行く」ボタン押下後の処理を実装
  - [x] モーダルのような形で、「Googleマップで行く」「Yahoo!カーナビで行く」という二つの選択肢を表示
  - [x] カルーセルアイテムで表示されている場所の緯度と経度を取得し、モーダル内の「Googleマップで行く」「Yahoo!カーナビで行く」というそれぞれのリンクの目的地として動的に設定する処理を実装
  - [x] それぞれのリンク押下後に各遷移先へ遷移するよう実装
- [x] 関連して、ドライブ履歴詳細画面とブックマーク詳細画面からも、表示対象となる目的地への経路案内を開始できるリンクを実装

