### PR TITLE
本番環境での403エラーの対応

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,7 +82,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Enable DNS rebinding protection and other `Host` header attacks.
-  config.hosts << 'www.your-next-destination.com'
+  config.hosts << 'your-next-destination.com'
 
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }


### PR DESCRIPTION
## 概要
ISSUE: #174 

- 独自ドメイン取得後にRender側の設定をしたものの、アプリURLに遷移すると403エラーが発生している状況となっているため、原因を調査して対応しました。

close #174 

## やったこと
- [x] `config/environment/production.rb`に追記している、許可対象とするホスト名の記述を修正