### PR TITLE
デプロイ後に発生したホストブロックエラーの対応  (mainブランチへマージ)

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,6 +82,7 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   # Enable DNS rebinding protection and other `Host` header attacks.
+  config.hosts << 'go-next.onrender.com'
   config.hosts << 'your-next-destination.com'
 
   # Skip DNS rebinding protection for the default health check endpoint.


### PR DESCRIPTION
## 概要
ISSUE: #186 

デプロイ後に発生したエラー (`[ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked hosts: go-next.onrender.com`)の対応を行いました

close #186 

## やったこと
`config/environments/production.rb`に、許可対象とするホストを追加