### PR TITLE
リロードせずに位置情報取得できるよう、原因特定して修正

### DIFF
--- a/app/views/searches/new.html.erb
+++ b/app/views/searches/new.html.erb
@@ -98,7 +98,7 @@
 </div>
 
 <script>
-  document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener('turbo:load', () => {
     const toggleButton = document.getElementById('toggle-form-button');
     const searchForm = document.getElementById('search-form');
 
@@ -135,24 +135,6 @@
       formElement.classList.remove('max-h-screen');
     }
   }
-
-  document.addEventListener('DOMContentLoaded', () => {
-    const dropdownFeelingButton = document.getElementById('dropdownFeelingButton');
-    const dropdownFeelingContent = document.getElementById('dropdownFeeling');
-
-    // 気分のドロップダウン制御
-    dropdownFeelingButton.addEventListener('click', (event) => {
-      dropdownFeelingContent.classList.toggle('hidden');
-      event.stopPropagation(); // ドキュメントのイベント伝播を停止
-    });
-
-    // ドロップダウン要素以外の場所がクリックされたらドロップダウンを閉じる
-    document.addEventListener('click', (event) => {
-      if (!dropdownFeelingButton.contains(event.target) && !dropdownFeelingContent.contains(event.target)) {
-        dropdownFeelingContent.classList.add('hidden');
-      }
-    });
-  });
 
   document.addEventListener('DOMContentLoaded', function() {
     const scrollToTopButton = document.getElementById('scrollToTop');


### PR DESCRIPTION
## 概要
ISSUE: #207 

トップページの「行き先を探す」ボタンで稀に生じていた、リロードしないと処理が実行されない不具合について、原因を調査し対応しました。

close #207

## やったこと
- 位置情報取得およびドロップダウン表示処理の起点を、DOM読み込み完了時からTurboによるページ読み込み完了時へと修正
  - TurboによってHTMLのbody部分のみを再読み込みしてページ遷移が行われている状況下で、上述の不具合が発生していたため、その形式のページ遷移時でも期待する処理が実行されるように修正した