### PR TITLE
位置情報取得処理の修正, ブックマークレコード生成に関わるテーブルのカラムにインデックス追加  (mainブランチへマージ)

### DIFF
--- a/app/views/searches/new.html.erb
+++ b/app/views/searches/new.html.erb
@@ -98,7 +98,7 @@
 </div>
 
 <script>
-  document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener('turbo:load', () => {
     const toggleButton = document.getElementById('toggle-form-button');
     const searchForm = document.getElementById('search-form');
 
@@ -135,24 +135,6 @@
       formElement.classList.remove('max-h-screen');
     }
   }
-
-  document.addEventListener('DOMContentLoaded', () => {
-    const dropdownFeelingButton = document.getElementById('dropdownFeelingButton');
-    const dropdownFeelingContent = document.getElementById('dropdownFeeling');
-
-    // 気分のドロップダウン制御
-    dropdownFeelingButton.addEventListener('click', (event) => {
-      dropdownFeelingContent.classList.toggle('hidden');
-      event.stopPropagation(); // ドキュメントのイベント伝播を停止
-    });
-
-    // ドロップダウン要素以外の場所がクリックされたらドロップダウンを閉じる
-    document.addEventListener('click', (event) => {
-      if (!dropdownFeelingButton.contains(event.target) && !dropdownFeelingContent.contains(event.target)) {
-        dropdownFeelingContent.classList.add('hidden');
-      }
-    });
-  });
 
   document.addEventListener('DOMContentLoaded', function() {
     const scrollToTopButton = document.getElementById('scrollToTop');

--- a/db/migrate/20240202072403_add_index_to_google_places_api_types.rb
+++ b/db/migrate/20240202072403_add_index_to_google_places_api_types.rb
@@ -1,0 +1,5 @@
+class AddIndexToGooglePlacesApiTypes < ActiveRecord::Migration[7.1]
+  def change
+    add_index :google_places_api_types, :name
+  end
+end

--- a/db/migrate/20240202072457_add_index_to_destinations.rb
+++ b/db/migrate/20240202072457_add_index_to_destinations.rb
@@ -1,0 +1,5 @@
+class AddIndexToDestinations < ActiveRecord::Migration[7.1]
+  def change
+    add_index :destinations, :google_places_api_id
+  end
+end

--- a/db/migrate/20240202110852_add_index_to_google_places_api_id_of_destinations.rb
+++ b/db/migrate/20240202110852_add_index_to_google_places_api_id_of_destinations.rb
@@ -1,0 +1,5 @@
+class AddIndexToGooglePlacesApiIdOfDestinations < ActiveRecord::Migration[7.1]
+  def change
+    add_index :destinations, :google_places_api_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_01_24_035248) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_02_110852) do
   create_table "authentications", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "provider", null: false
@@ -33,8 +33,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_24_035248) do
   create_table "destinations", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "name"
     t.string "address"
-    t.decimal "latitude", precision: 8, scale: 6
-    t.decimal "longitude", precision: 9, scale: 6
+    t.decimal "latitude", precision: 9, scale: 7
+    t.decimal "longitude", precision: 10, scale: 7
     t.bigint "google_places_api_type_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -42,6 +42,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_24_035248) do
     t.string "website_uri"
     t.string "google_places_api_id"
     t.string "photo_uri"
+    t.index ["google_places_api_id"], name: "index_destinations_on_google_places_api_id"
     t.index ["google_places_api_type_id"], name: "index_destinations_on_google_places_api_type_id"
   end
 
@@ -75,6 +76,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_01_24_035248) do
     t.string "display_name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_google_places_api_types_on_name"
   end
 
   create_table "users", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|


### PR DESCRIPTION
## 概要

ISSUE: #207, #219 

以下の実装を行いました。
- トップページの「行き先を探す」ボタンで稀に生じていた、リロードしないと処理が実行されない不具合について、原因を調査し対応
- ブックマーク処理の速度向上のため、当該処理に関わるテーブルのカラムにindexを貼る

## やったこと
以下のプルリクエストをご参照ください。

- [リロードせずに位置情報取得できるよう、原因特定して修正](https://github.com/Dai-44/go-next/pull/218)
- [ブックマーク処理の速度向上のため、当該処理に関わるテーブルのカラムにindexを貼る](https://github.com/Dai-44/go-next/pull/220)