### PR TITLE
デプロイエラーの解消

### DIFF
--- a/app/views/destinations/show.html.erb
+++ b/app/views/destinations/show.html.erb
@@ -50,7 +50,7 @@
 
 <script>
   // 「ここへ行く」ボタンをクリックした際のドロップダウン表示処理
-  document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener('turbo:load', () => {
     const dropdownDepartureButton = document.getElementById('dropdownDepartureButton');
     const dropdownDepartureContent = document.getElementById('dropdownDeparture');
     const overlay = document.getElementById('overlay');

--- a/app/views/drive_records/show.html.erb
+++ b/app/views/drive_records/show.html.erb
@@ -53,7 +53,7 @@
 
 <script>
   // 「もう一度行く」ボタンをクリックした際のドロップダウン表示処理
-  document.addEventListener('DOMContentLoaded', () => {
+  document.addEventListener('turbo:load', () => {
     const dropdownDepartureButton = document.getElementById('dropdownDepartureButton');
     const dropdownDepartureContent = document.getElementById('dropdownDeparture');
     const overlay = document.getElementById('overlay');

--- a/app/views/searches/new.html.erb
+++ b/app/views/searches/new.html.erb
@@ -136,7 +136,7 @@
     }
   }
 
-  document.addEventListener('DOMContentLoaded', function() {
+  document.addEventListener('turbo:load', function() {
     const scrollToTopButton = document.getElementById('scrollToTop');
 
     scrollToTopButton.addEventListener('click', function(event) {

--- a/db/migrate/20240202110852_add_index_to_google_places_api_id_of_destinations.rb
+++ b/db/migrate/20240202110852_add_index_to_google_places_api_id_of_destinations.rb
@@ -1,5 +1,0 @@
-class AddIndexToGooglePlacesApiIdOfDestinations < ActiveRecord::Migration[7.1]
-  def change
-    add_index :destinations, :google_places_api_id
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_02_02_110852) do
+ActiveRecord::Schema[7.1].define(version: 2024_02_02_072457) do
   create_table "authentications", charset: "utf8mb4", collation: "utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "provider", null: false
@@ -42,7 +42,6 @@ ActiveRecord::Schema[7.1].define(version: 2024_02_02_110852) do
     t.string "website_uri"
     t.string "google_places_api_id"
     t.string "photo_uri"
-    t.index ["google_places_api_id"], name: "index_destinations_on_google_places_api_id"
     t.index ["google_places_api_type_id"], name: "index_destinations_on_google_places_api_type_id"
   end
 


### PR DESCRIPTION
## 概要
ISSUE: #222 

デプロイ時に発生したマイグレーションエラーの対応を行いました。

close #222 

## やったこと
- Destinationsテーブルのgoogle_place_api_idカラムへindexを追加するマイグレーションファイルを2つ作成していたことが原因でエラーが発生したため、1つへ修正して再度デプロイ